### PR TITLE
fix: use local links everywhere

### DIFF
--- a/src/content/docs/codebase-best-practices.md
+++ b/src/content/docs/codebase-best-practices.md
@@ -24,7 +24,7 @@ We are striving to support right-to-left (RTL) layout in the codebase for langua
 
 ## General JavaScript
 
-In most cases, our [linter](how-to-setup-freecodecamp-locally#follow-these-steps-to-get-your-development-environment-ready) will warn of any formatting which goes against this codebase's preferred practice.
+In most cases, our [linter](/how-to-setup-freecodecamp-locally#follow-these-steps-to-get-your-development-environment-ready) will warn of any formatting which goes against this codebase's preferred practice.
 
 It is encouraged to use functional components over class-based components.
 

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -18,7 +18,7 @@ Yes - You can contribute to any of the 30+ languages we have enabled on our tran
 
 We have user-contributed translations live in some languages. We intend to localize freeCodeCamp into several major world languages. You can read all about this in our [announcement here](https://www.freecodecamp.org/news/help-translate-freecodecamp-language/).
 
-If you are interested in contributing to translations please make sure you [read this guide](how-to-translate-files) first.
+If you are interested in contributing to translations please make sure you [read this guide](/how-to-translate-files) first.
 
 ## Can I contribute articles to freeCodeCamp News or videos to freeCodeCamp's YouTube channel?
 
@@ -93,7 +93,7 @@ Altogether, be respectful to others. We are humans from all around the world. Wi
 
 If you practice the above **consistently for a while** and our fellow moderator members recommend you, a staff member will reach out and onboard you to the moderators' team. Open source work is voluntary work and our time is limited. We acknowledge that this is probably true in your case as well. So we emphasize being **consistent** rather than engaging in the community 24/7.
 
-Take a look at our [Moderator Handbook](moderator-handbook) for a more exhaustive list of other responsibilities and expectations we have of our moderators.
+Take a look at our [Moderator Handbook](/moderator-handbook) for a more exhaustive list of other responsibilities and expectations we have of our moderators.
 
 ## I am stuck on something that is not included in this documentation.
 

--- a/src/content/docs/how-to-add-cypress-tests.md
+++ b/src/content/docs/how-to-add-cypress-tests.md
@@ -15,14 +15,14 @@ To learn how to write Cypress tests, or 'specs', please see Cypress' official [d
 ## How to Run Tests
 
 :::note
-If using Gitpod, please see [Cypress-Gitpod Setup](how-to-add-cypress-tests#cypress-gitpod-setup)
+If using Gitpod, please see [Cypress-Gitpod Setup](/how-to-add-cypress-tests#cypress-gitpod-setup)
 :::
 
 ### 1. Ensure that MongoDB and Client Applications are Running
 
-- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database)
+- [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database)
 
-- [Start the freeCodeCamp client application and API server](how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
+- [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
 
 ### 2. Run the Cypress Tests
 
@@ -85,7 +85,7 @@ pnpm run cypress:install-build-tools
 
 - When prompted in the terminal, select your keyboard layout by language/area
 
-Now, [Cypress can be run](how-to-add-cypress-tests#_2-run-the-cypress-tests)
+Now, [Cypress can be run](/how-to-add-cypress-tests#_2-run-the-cypress-tests)
 
 ## Troubleshooting
 

--- a/src/content/docs/how-to-add-playwright-tests.md
+++ b/src/content/docs/how-to-add-playwright-tests.md
@@ -157,9 +157,9 @@ describe('The campers landing page', () => {
 
 ### Ensure that MongoDB and Client Applications are Running
 
-- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database). In order for Playwright tests to work, be sure that you use the `pnpm run seed:certified-user` command.
+- [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database). In order for Playwright tests to work, be sure that you use the `pnpm run seed:certified-user` command.
 
-- [Start the freeCodeCamp client application and API server](how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
+- [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
 
 ### Run the Playwright Tests
 

--- a/src/content/docs/how-to-contribute-to-the-codebase.md
+++ b/src/content/docs/how-to-contribute-to-the-codebase.md
@@ -7,7 +7,7 @@ Ignoring these steps may soil your copy which makes the contributing, maintainin
 
 ## Contributing to the Codebase
 
-You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freeCodeCamp locally](how-to-setup-freecodecamp-locally).
+You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally).
 
 Follow these steps:
 
@@ -201,7 +201,7 @@ The resulting output should be empty. This process is important, because you wil
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).
 
 ## Quick commands reference
 

--- a/src/content/docs/how-to-enable-new-languages.md
+++ b/src/content/docs/how-to-enable-new-languages.md
@@ -237,7 +237,7 @@ You don't have to have everything in these 3 files translated at first. It's pos
 
 You can replace any URLs that you have corresponding pages ready in your language.
 
-For example, if you have a publication in your language, you can replace the URL for `"news"`. If you want to translate articles listed in the footer links, see [How to Translate Articles in the Footer Links](language-lead-handbook#how-to-translate-articles-in-the-footer-links).
+For example, if you have a publication in your language, you can replace the URL for `"news"`. If you want to translate articles listed in the footer links, see [How to Translate Articles in the Footer Links](/language-lead-handbook#how-to-translate-articles-in-the-footer-links).
 
 #### `meta-tags.json`
 

--- a/src/content/docs/how-to-help-with-video-challenges.md
+++ b/src/content/docs/how-to-help-with-video-challenges.md
@@ -93,7 +93,7 @@ Skim the YouTube video with that `videoId` and think of a multiple-choice questi
 
 ### Add the Question to the Markdown File
 
-You can add the question locally or using the GitHub interface. To add the question locally, you need to [set up freeCodeCamp locally](how-to-setup-freecodecamp-locally). You can also find the file on GitHub and click the edit button to add the question right in your browser.
+You can add the question locally or using the GitHub interface. To add the question locally, you need to [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally). You can also find the file on GitHub and click the edit button to add the question right in your browser.
 
 If a question has not yet been added to a particular video challenge, it will have the following default question:
 
@@ -205,4 +205,4 @@ For more examples, you can look at the markdown files for the following video co
 
 ## Open a Pull Request
 
-After creating one or more questions, you can commit the changes to a new branch and [open a pull request](how-to-open-a-pull-request).
+After creating one or more questions, you can commit the changes to a new branch and [open a pull request](/how-to-open-a-pull-request).

--- a/src/content/docs/how-to-open-a-pull-request.md
+++ b/src/content/docs/how-to-open-a-pull-request.md
@@ -19,7 +19,7 @@ Some examples of this are:
 6. Do not work directly off your `main` branch - create a new branch for the changes you are working on.
 
 :::note
-Your PR should be targeting changes to the English curriculum only. Read [this guide](intro#translations) instead for contributing to translations.
+Your PR should be targeting changes to the English curriculum only. Read [this guide](/intro#translations) instead for contributing to translations.
 :::
 
 ## Prepare a Good PR Title
@@ -97,7 +97,7 @@ Some examples of good PR titles would be:
 
    - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML, which could change the functionality or layout of a page.
 
-   - If your PR affects the behavior of a page, it should be accompanied by corresponding [Playwright integration tests](how-to-add-playwright-tests).
+   - If your PR affects the behavior of a page, it should be accompanied by corresponding [Playwright integration tests](/how-to-add-playwright-tests).
 
 ## Feedback on Pull Requests
 
@@ -108,7 +108,7 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://discord.gg/PRyKn3Vbay).
 
 :::tip
-If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](how-to-setup-freecodecamp-locally#making-changes-locally) guidelines to avoid having to delete your fork.
+If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-setup-freecodecamp-locally#making-changes-locally) guidelines to avoid having to delete your fork.
 :::
 
 ## Conflicts on a Pull Request

--- a/src/content/docs/how-to-proofread-files.md
+++ b/src/content/docs/how-to-proofread-files.md
@@ -17,7 +17,7 @@ You should see the list of projects you have been granted access to. Select the 
 You should now see the list of available files. Choose your file by selecting the `Proofread` button on the right of that file, then choosing `Proofreading` from the drop-down menu that appears.
 
 :::note
-If you are in this workspace view, but want to work on [translating a file](how-to-translate-files) instead of proofreading, you may select `Crowdsourcing` from the dropdown menu instead.
+If you are in this workspace view, but want to work on [translating a file](/how-to-translate-files) instead of proofreading, you may select `Crowdsourcing` from the dropdown menu instead.
 :::
 
 ## Proofread Translations

--- a/src/content/docs/how-to-setup-freecodecamp-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.md
@@ -8,9 +8,9 @@ Follow these guidelines for setting up a development environment for freeCodeCam
 
 :::danger
 
-- freeCodeCamp does not build and run natively on Windows, you will [need to use WSL2](how-to-setup-wsl) for a Linux-like setup on Windows.
+- freeCodeCamp does not build and run natively on Windows, you will [need to use WSL2](/how-to-setup-wsl) for a Linux-like setup on Windows.
 - You can't use Windows Command Prompt, Git Bash or PowerShell to build and run the codebase.
-- Note that if using Windows, the hardware requirements need to be more than [what we mention](how-to-setup-freecodecamp-locally?id=how-to-prepare-your-local-machine) to accommodate for WSL-based setup.
+- Note that if using Windows, the hardware requirements need to be more than [what we mention](/how-to-setup-freecodecamp-locally?id=how-to-prepare-your-local-machine) to accommodate for WSL-based setup.
 
 :::
 
@@ -70,7 +70,7 @@ Here is a minimum system requirement for running freeCodeCamp locally:
 
 Start by installing the prerequisite software for your operating system.
 
-We primarily support development on Linux and Unix-based systems like Ubuntu and macOS. You can develop on Windows 10 or 11 with WSL2 only. You can follow [this guide](how-to-setup-wsl) to set up WSL2. You can't use Command Prompt, Git Bash or PowerShell to run freeCodeCamp natively within windows.
+We primarily support development on Linux and Unix-based systems like Ubuntu and macOS. You can develop on Windows 10 or 11 with WSL2 only. You can follow [this guide](/how-to-setup-wsl) to set up WSL2. You can't use Command Prompt, Git Bash or PowerShell to run freeCodeCamp natively within windows.
 
 #### Prerequisites:
 
@@ -81,7 +81,7 @@ We primarily support development on Linux and Unix-based systems like Ubuntu and
 | [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `5.0.x` | -                                                                                           |
 
 :::danger
-If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting section](troubleshooting-development-issues) for details.
+If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting section](/troubleshooting-development-issues) for details.
 :::
 
 If Node.js is already installed on your machine, run the following commands to validate the versions:
@@ -253,7 +253,7 @@ Before you can run the application locally, you will need to start the MongoDB s
 :::note
 Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
 
-If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
+If you followed along with the [Windows 10 via WSL2 Setup Guide](/how-to-setup-wsl), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
 :::
 Start the MongoDB server in a separate terminal:
 
@@ -301,7 +301,7 @@ While you are logged in, if you visit <http://localhost:3000/explorer> you shoul
 Clearing your cookies or running `pnpm run seed:certified-user` will log you out, and you will have to sign in again.
 :::
 
-If you have issues while installing it, check out the [troubleshooting section](troubleshooting-development-issues).
+If you have issues while installing it, check out the [troubleshooting section](/troubleshooting-development-issues).
 
 ## Quick Commands Reference
 

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
@@ -475,7 +475,7 @@ You only need to follow this section if you're modifying the challenge test runn
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).
 
 <!-- ## Quick commands reference - NEED TO DISCUSS ABOUT THIS
 

--- a/src/content/docs/how-to-setup-wsl.md
+++ b/src/content/docs/how-to-setup-wsl.md
@@ -10,7 +10,7 @@ Before you follow these instructions make sure your system meets the requirement
 **Docker Desktop for Windows**: See respective requirements for [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/#system-requirements) and [Windows 10 Home](https://docs.docker.com/docker-for-windows/install-windows-home/#system-requirements)
 :::
 
-This guide covers some common steps with the setup of WSL2. Once some of the common issues with WSL2 are addressed, you should be able to follow [this local setup guide](how-to-setup-freecodecamp-locally) to work with freeCodeCamp on Windows running a WSL distro like Ubuntu.
+This guide covers some common steps with the setup of WSL2. Once some of the common issues with WSL2 are addressed, you should be able to follow [this local setup guide](/how-to-setup-freecodecamp-locally) to work with freeCodeCamp on Windows running a WSL distro like Ubuntu.
 
 ## Enable WSL
 
@@ -78,7 +78,7 @@ Once you have configured Docker Desktop to work with WSL2, follow these steps to
 
 1. Launch a new Ubuntu terminal
 
-2. Pull MongoDB from Docker Hub. Please refer to the [Prerequisites](how-to-setup-freecodecamp-locally#Prerequisites) table for the current version of MongoDB used by freeCodeCamp. For example, if the version number is `5.0.x`, replace `<x.y>` with `5.0` in the following two code snippets.
+2. Pull MongoDB from Docker Hub. Please refer to the [Prerequisites](/how-to-setup-freecodecamp-locally#Prerequisites) table for the current version of MongoDB used by freeCodeCamp. For example, if the version number is `5.0.x`, replace `<x.y>` with `5.0` in the following two code snippets.
 
    ```bash
    docker pull mongo:<x.y>
@@ -117,7 +117,7 @@ npm install -g pnpm
 
 ## Set up freeCodeCamp Locally
 
-Now that you have installed the pre-requisites, follow [our local setup guide](how-to-setup-freecodecamp-locally) to clone, install and set up freeCodeCamp locally on your machine.
+Now that you have installed the pre-requisites, follow [our local setup guide](/how-to-setup-freecodecamp-locally) to clone, install and set up freeCodeCamp locally on your machine.
 
 :::warning
 Please note, at this time the setup for Cypress tests (and related GUI needs) is a work in progress. You should still be able to work on most of the codebase.

--- a/src/content/docs/how-to-translate-files.md
+++ b/src/content/docs/how-to-translate-files.md
@@ -147,7 +147,7 @@ Our `/learn` interface relies on JSON files loaded into an i18n plugin to genera
 
 The `links.json`, `meta-tags.json`, `motivation.json`, and `trending.json` files contain information that needs to be updated to reflect your language. However, we cannot load these into Crowdin, as the content isn't something that would be a one-to-one translation.
 
-These files will most likely be maintained by your language lead but you are welcome to [read about how to translate them](language-lead-handbook).
+These files will most likely be maintained by your language lead but you are welcome to [read about how to translate them](/language-lead-handbook).
 
 ### On Crowdin
 
@@ -203,9 +203,9 @@ After translation
 
 The actual files in docs are written in Markdown, but they will appear as HTML tags on Crowdin.
 
-You can find out how `docsify` converts a string in your language into an id by looking into the translated pages. If the translation is not deployed yet, you can preview it by [running the docs site locally](how-to-work-on-the-docs-theme#serving-the-documentation-site-locally).
+You can find out how `docsify` converts a string in your language into an id by looking into the translated pages. If the translation is not deployed yet, you can preview it by [running the docs site locally](/how-to-work-on-the-docs-theme#serving-the-documentation-site-locally).
 
-You can learn more about [internal links in our docs here](how-to-work-on-the-docs-theme#how-to-create-an-internal-link).
+You can learn more about [internal links in our docs here](/how-to-work-on-the-docs-theme#how-to-create-an-internal-link).
 
 ## Translate the LearnToCode RPG
 

--- a/src/content/docs/how-to-work-on-coding-challenges.md
+++ b/src/content/docs/how-to-work-on-coding-challenges.md
@@ -24,14 +24,14 @@ You can find all of freeCodeCamp.org's curricular content in the [`/curriculum/c
 
 Before you work on the curriculum, you would need to set up some tooling to help you test your changes. You can use any option from the below:
 
-- You can [set up freeCodeCamp locally](how-to-setup-freecodecamp-locally). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
+- You can [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
 - Use Gitpod, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
 
   [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
 
 ### How to work on practice projects
 
-The practice projects have some additional tooling to help create new projects and steps. To read more, see [these docs](how-to-work-on-practice-projects)
+The practice projects have some additional tooling to help create new projects and steps. To read more, see [these docs](/how-to-work-on-practice-projects)
 
 ## Challenge Template
 
@@ -596,7 +596,7 @@ function myFunc() {
 
 ## Testing Challenges
 
-Before you [create a pull request](how-to-open-a-pull-request) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge.
+Before you [create a pull request](/how-to-open-a-pull-request) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge.
 
 1. To test all challenges run the below command from the root directory
 
@@ -642,7 +642,7 @@ The currently accepted values are `english` and `chinese`, with `english` being 
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).
 
 ## Useful Links
 
@@ -655,7 +655,7 @@ Creating and Editing Challenges:
 ## Helper Scripts
 
 :::note
-If you are working with the step-based challenges, refer to the [Work on Practice Projects](how-to-work-on-practice-projects) section.
+If you are working with the step-based challenges, refer to the [Work on Practice Projects](/how-to-work-on-practice-projects) section.
 :::
 
 There are a few helper scripts that can be used to manage the challenges in a block. Note that these commands should all be run in the block directory. For example:

--- a/src/content/docs/how-to-work-on-localized-client-webapp.md
+++ b/src/content/docs/how-to-work-on-localized-client-webapp.md
@@ -4,14 +4,14 @@ title: How to Work on Localized Client Webapp
 
 The React-based client web app that powers our learning platform is built using Gatsby. It is translated into various world languages using [react-i18next](https://react.i18next.com/) and [i18next](https://www.i18next.com/).
 
-You can learn more about setting up the client application locally for development by following [our local setup guide here](how-to-setup-freecodecamp-locally). By default, the application is available only in English.
+You can learn more about setting up the client application locally for development by following [our local setup guide here](/how-to-setup-freecodecamp-locally). By default, the application is available only in English.
 
 Once you have set up the project locally you should be able to follow this documentation to run the client in the language of your choice from the list of available languages.
 
 This could be helpful when you are working on a feature that specifically targets something that involves localization, and requires you to validate for instance a button's label in a different language.
 
 :::tip
-You do not need to follow this document to translate freeCodeCamp's curriculum or contributing documentation. Read [this guide here](how-to-translate-files) instead.
+You do not need to follow this document to translate freeCodeCamp's curriculum or contributing documentation. Read [this guide here](/how-to-translate-files) instead.
 :::
 
 Let's understand how the i18n frameworks and tooling work.
@@ -67,7 +67,7 @@ Some of these files are translated on our translation platform (Crowdin) and som
 
 - The `intro.json` file contains the key-value pairs for the introduction text on the certification pages.
 
-  If you want to add/update translations for the keys please [read this guide here](how-to-translate-files).
+  If you want to add/update translations for the keys please [read this guide here](/how-to-translate-files).
 
 **Files NOT translated on our translations platform:**
 
@@ -280,7 +280,7 @@ Run `pnpm run clean-and-develop` to apply the change.
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).
 
 ## Helpful Documentation
 

--- a/src/content/docs/how-to-work-on-practice-projects.md
+++ b/src/content/docs/how-to-work-on-practice-projects.md
@@ -186,4 +186,4 @@ The script identify the English files as the source of truth using the challenge
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).

--- a/src/content/docs/how-to-work-on-the-component-library.md
+++ b/src/content/docs/how-to-work-on-the-component-library.md
@@ -97,7 +97,7 @@ pnpm run test-ui-components
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).
 
 ## Adding Packages to the UI-Component Library
 

--- a/src/content/docs/how-to-work-on-the-docs-theme.md
+++ b/src/content/docs/how-to-work-on-the-docs-theme.md
@@ -25,7 +25,7 @@ This is necessary to make these links work for the translated version of the doc
 
 #### Translating docs with internal links
 
-When you work on translating docs on Crowdin, make sure to replace the `#target-section-heading-id` with the id on the translated document. [Learn more about translating docs here](how-to-translate-files#translate-documentation).
+When you work on translating docs on Crowdin, make sure to replace the `#target-section-heading-id` with the id on the translated document. [Learn more about translating docs here](/how-to-translate-files#translate-documentation).
 
 ## Work on the Docs Theme
 
@@ -50,7 +50,7 @@ Typically you would not need to change any configuration or build the site local
 
 ### Serving the Documentation Site Locally
 
-Install freeCodeCamp locally ([see the local setup guide](how-to-setup-freecodecamp-locally)), we bundled the CLI with the development tools so you can run the command below as needed from the root of the repo:
+Install freeCodeCamp locally ([see the local setup guide](/how-to-setup-freecodecamp-locally)), we bundled the CLI with the development tools so you can run the command below as needed from the root of the repo:
 
 ```bash
 pnpm run docs:serve
@@ -60,4 +60,4 @@ pnpm run docs:serve
 
 ## Proposing a Pull Request (PR)
 
-After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request).
+After you've committed your changes, check here for [how to open a Pull Request](/how-to-open-a-pull-request).

--- a/src/content/docs/intro.md
+++ b/src/content/docs/intro.md
@@ -10,7 +10,7 @@ Before you proceed, please take a quick 2 minutes to read our [Code of Conduct](
 
 You are welcome to create, update and fix bugs in our [curriculum](#curriculum), help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform), or [help us translate](#translations) freeCodeCamp.org to world languages.
 
-We answer the most common questions about contributing [in our contributor FAQ](faq).
+We answer the most common questions about contributing [in our contributor FAQ](/faq).
 
 Happy contributing.
 
@@ -22,7 +22,7 @@ Our curriculum is curated by the global freeCodeCamp community. This way, we are
 
 You can help expand and improve the curriculum. You can also update project user stories to better-explain concepts. And you can improve our automated tests so that we can more accurately test people's code.
 
-**If you're interested in improving our curriculum, here's [how to contribute to the curriculum](how-to-work-on-coding-challenges).**
+**If you're interested in improving our curriculum, here's [how to contribute to the curriculum](/how-to-work-on-coding-challenges).**
 
 ## Translations
 
@@ -40,7 +40,7 @@ Certifications are already live in some major world languages like below:
 
 We encourage you to read the [announcement here](https://www.freecodecamp.org/news/help-translate-freecodecamp-language/) and share it with your friends to get them excited about this.
 
-**If you're interested in translating, here's [how to translate freeCodeCamp's resources](how-to-translate-files).**
+**If you're interested in translating, here's [how to translate freeCodeCamp's resources](/how-to-translate-files).**
 
 ## Learning Platform
 
@@ -48,4 +48,4 @@ Our learning platform runs on a modern JavaScript stack. It has various componen
 
 Broadly, we have a Node.js based API server, a set of React-based client applications, testing scripts to evaluate camper-submitted curriculum projects, and more. If you want to productively contribute to the learning platform, we recommend some familiarity with these tools.
 
-**If you want to help us improve our codebase here's [how to set up freeCodeCamp](how-to-setup-freecodecamp-locally).**
+**If you want to help us improve our codebase here's [how to set up freeCodeCamp](/how-to-setup-freecodecamp-locally).**

--- a/src/content/docs/language-lead-handbook.md
+++ b/src/content/docs/language-lead-handbook.md
@@ -67,7 +67,7 @@ Each number represents one of the 30 articles in the footer. Make sure to match 
 
 For each article, you will need to create a shorter title to use in the footer. Each title must stay on a single line and not go to a new line.
 
-You will want to [build the translated client locally](how-to-enable-new-languages) to see if the titles have the right length. You can preview the changes by editing the `trending.json` file in your local environment:
+You will want to [build the translated client locally](/how-to-enable-new-languages) to see if the titles have the right length. You can preview the changes by editing the `trending.json` file in your local environment:
 
 1. Update your `.env` file to use your language for `CLIENT_LOCALE` and `CURRICULUM_LOCALE`.
 
@@ -371,9 +371,9 @@ Search for the user who will become a proofreader. Use the three dots menu on th
 The user is now a proofreader.
 
 :::tip
-The newly promoted proofreader could benefit from reading the [How to Proofread Files](how-to-proofread-files) documentation.
+The newly promoted proofreader could benefit from reading the [How to Proofread Files](/how-to-proofread-files) documentation.
 :::
 
 ## How to Add or Update a Language
 
-Check out the [how to enable new language](how-to-enable-new-languages) docs. If you are updating a language the section on [set translated superblocks](how-to-enable-new-languages#set-translated-superblocks) should be helpful.
+Check out the [how to enable new language](/how-to-enable-new-languages) docs. If you are updating a language the section on [set translated superblocks](/how-to-enable-new-languages#set-translated-superblocks) should be helpful.

--- a/src/content/docs/moderator-handbook.md
+++ b/src/content/docs/moderator-handbook.md
@@ -23,7 +23,7 @@ freeCodeCamp is an inclusive community, and we need to keep it that way.
 We have a single [Code of Conduct](https://code-of-conduct.freecodecamp.org) that governs our entire community. The fewer the rules, the easier they are to remember. You can read those rules and commit them to memory [here](https://code-of-conduct.freecodecamp.org).
 
 :::note
-As a moderator, we would add you to one or more teams on GitHub, our community forums & chat servers. If you are missing access to a platform that you would like to moderate, please [reach out to a staff member](faq#additional-assistance).
+As a moderator, we would add you to one or more teams on GitHub, our community forums & chat servers. If you are missing access to a platform that you would like to moderate, please [reach out to a staff member](/faq#additional-assistance).
 :::
 
 ## Moderating GitHub
@@ -45,7 +45,7 @@ You can help us organize and triage the issue reports by applying labels from [t
 
 Please pay special attention to the labels `"help wanted"` and `"first timers only"`. These are to be added to threads that you think can be opened up to potential contributors for making a pull request.
 
-For triaging a trivial issue such as a typo fix, it is recommended to apply a "first timers only" label along with additional information. You can utilize the [reply template](reply-templates#first-timer-only-issues) provided for this purpose.
+For triaging a trivial issue such as a typo fix, it is recommended to apply a "first timers only" label along with additional information. You can utilize the [reply template](/reply-templates#first-timer-only-issues) provided for this purpose.
 
 #### Closing Stale, Outdated, Inactive Issues and Pull Requests
 
@@ -56,7 +56,7 @@ For triaging a trivial issue such as a typo fix, it is recommended to apply a "f
 - If the contributor asks for additional assistance or even time, the above can be relaxed and revisited after a response is given. In any case, the mods should use their best judgment to resolve the outstanding PR's status.
 
 :::tip
-We recommend you use this list of standard [reply templates](reply-templates) while triaging issues.
+We recommend you use this list of standard [reply templates](/reply-templates) while triaging issues.
 :::
 
 ### Moderating Pull Requests
@@ -71,7 +71,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    You can also review these right on GitHub and decide whether to merge them. We need to be a bit more careful about these because millions of people will encounter this text as they work through the freeCodeCamp curriculum. Does the pull request make the text more clear without making it much longer? Are the edits relevant and not overly pedantic? Remember that our goal is for challenges to be as clear and as short as possible. They aren't the place for obscure details. Contributors may try to add links to resources to the challenges.
 
-   You can close invalid pull requests and reply to them with these [reply templates](reply-templates#closing-invalid-pull-requests).
+   You can close invalid pull requests and reply to them with these [reply templates](/reply-templates#closing-invalid-pull-requests).
 
    If the changes look good, please ensure to leave an approval with a "LGTM" (Looks Good To Me) comment. Once a pull request gets at least two approvals (including yours) from the moderators or the dev-team, you can go ahead and merge it.
 
@@ -83,7 +83,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    Some contributors may try to add additional tests to cover pedantic corner-cases. We need to be careful to not make the challenge too complicated. These challenges and their tests should be as simple and intuitive as possible. Aside from the algorithm challenges and interview prep section, learners should be able to solve each challenge within about 2 minutes.
 
-   You can close invalid pull requests and reply to them with these [reply templates](reply-templates#closing-invalid-pull-requests).
+   You can close invalid pull requests and reply to them with these [reply templates](/reply-templates#closing-invalid-pull-requests).
 
    If the changes look good, please ensure to leave an approval with an "LGTM" comment. Once a pull request gets at least two approvals (including yours) from the moderators or the dev-team, you can go ahead and merge it.
 
@@ -151,7 +151,7 @@ Often, a pull request will be low effort. You can usually tell this immediately 
 
 There are also situations where the contributor is trying to add a link to their website, include a library they created, or have a frivolous edit that doesn't help anyone but themselves.
 
-You can close these invalid pull requests and reply to them with these [reply templates](reply-templates#closing-invalid-pull-requests).
+You can close these invalid pull requests and reply to them with these [reply templates](/reply-templates#closing-invalid-pull-requests).
 
 #### Filtering Pull Requests
 

--- a/src/content/docs/security-hall-of-fame.md
+++ b/src/content/docs/security-hall-of-fame.md
@@ -2,7 +2,7 @@
 title: Responsible Disclosure - Hall of Fame
 ---
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. If you are interested in contributing to the security of our platform, please read our [security policy outlined here](security).
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. If you are interested in contributing to the security of our platform, please read our [security policy outlined here](/security).
 
 While we do not offer any bounties or swags at the moment, we are grateful to these awesome people for helping us keep the platform safe for everyone:
 

--- a/src/content/docs/security.md
+++ b/src/content/docs/security.md
@@ -16,7 +16,7 @@ We appreciate responsible disclosure of vulnerabilities that might impact the in
 
 1. Ensure that you are using the **latest**, **stable**, and **updated** versions of the Operating System and Web Browser(s) available to you on your machine.
 2. We consider using tools & online utilities to report issues with SPF & DKIM configs, SSL Server tests, etc., in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties) and are unable to respond to these reports.
-3. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](security-hall-of-fame) list, provided the reports are not low-effort.
+3. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](/security-hall-of-fame) list, provided the reports are not low-effort.
 
 ### Reporting
 

--- a/src/content/docs/troubleshooting-development-issues.md
+++ b/src/content/docs/troubleshooting-development-issues.md
@@ -87,7 +87,7 @@ If you are using Apple Devices with M1 Chip to run the application locally, it i
 
 ## Working With Other Languages
 
-To see how the client renders in another language go to [testing the client app in a world language.](how-to-work-on-localized-client-webapp#Testing-the-Client-App-in-a-World-Language)
+To see how the client renders in another language go to /how-to-work-on-localized-client-webapp#Testing-the-Client-App-in-a-World-Language)
 
 ## Getting Help
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
All of the URLS have been updated on the English pages. I did my best to try to grab all the foreign ones, though it is possible I missed one or two. But the experiment with the URLs proved that the links redirect back to the English ones, regardless of what language the page is supposed to be in. 