### PR TITLE
fix: re-route ids 

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,11 @@
+import { defineMiddleware } from 'astro:middleware';
+
+// `context` and `next` are automatically typed
+export const onRequest = defineMiddleware((context, next) => {
+  let urlString = context.url.toString();
+  if (urlString.includes('#/') || urlString.includes('?id=')) {
+    urlString = urlString.replace('#/', '').replace('?id=', '/#');
+    return Response.redirect(new URL(urlString), 302);
+  }
+  return next();
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #79

<!-- Feel free to add any additional description of changes below this line -->
It does redirect the query string ids to proper ids. However I am not able to modify the "#/" routes since they seem to match the main homepage. 