### PR TITLE
chore: bump pnpm to v9 in the contribute docs

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.md
@@ -77,7 +77,7 @@ We primarily support development on Linux and Unix-based systems like Ubuntu and
 | Prerequisite                                                                                  | Version | Notes                                                                                       |
 | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
 | [Node.js](http://nodejs.org)                                                                  | `20.x`  | We use the "Active LTS" version, See [LTS Schedule](https://nodejs.org/en/about/releases/). |
-| [pnpm](https://pnpm.io/installation)                                                          | `8.x`   | -                                                                                           |
+| [pnpm](https://pnpm.io/installation)                                                          | `9.x`   | -                                                                                           |
 | [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `5.0.x` | -                                                                                           |
 
 :::danger


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

This is a PR to ensure that the `pnpm` version in the docs is in sync with what is needed to run the project after @raisedadead's [pnpm bump change](https://github.com/juancaorg/freeCodeCamp/commit/dabea4a904460c67c7341cc2dec60149670dad3a).

How did I realize this? Because I was that guy configuring `pnpm` for version 8 (because it wasn't working with version 9 when running the fCC project and this was mentioned in the docs) last night, only to wake up today and realize that `pnpm` version 8 didn't work anymore 🥲