### PR TITLE
fix:Contributing guidelines landing page redirects to incorrect link

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -31,7 +31,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     [Help us translate](/index?id=translations) freeCodeCamp.org's resources.
   </Card>
   <Card title='Open Source' icon='github'>
-    [Contribute to our open-source codebase](https://github.com/freeCodeCamp/freeCodeCamp) on
-    GitHub.
+    [Contribute to our open-source
+    codebase](https://github.com/freeCodeCamp/freeCodeCamp) on GitHub.
   </Card>
 </CardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -31,7 +31,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     [Help us translate](/index?id=translations) freeCodeCamp.org's resources.
   </Card>
   <Card title='Open Source' icon='github'>
-    [Contribute to our open-source codebase](/index?id=learning-platform) on
+    [Contribute to our open-source codebase](https://github.com/freeCodeCamp/freeCodeCamp) on
     GitHub.
   </Card>
 </CardGrid>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #117

<!-- Feel free to add any additional description of changes below this line -->
On the Contributing Guidelines landing page, the fourth link down which reads “Contribute to our open-source codebase on GitHub” currently redirects users to the Learning Platform subsection of the contributing guidelines. This is misleading as the language and icon used both imply that it will direct users to the GitHub repository so changed the url path to the github repo of the freecoursesite.
