### PR TITLE
fix: sidebar background color cut off

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -98,8 +98,11 @@ option[data-theme='dark'] .icon[data-theme='dark'] {
 
 /****** Sidebar ******/
 
-.sidebar-content {
+.sidebar-pane {
   background-color: var(--primary-background);
+}
+
+.sidebar-content {
   color: var(--quaternary-color);
   padding: 0;
 }


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- Background-color of the sidebar was ending at the end of initial screen height: https://github.com/freeCodeCamp/contribute/assets/60067306/47f204fe-ef07-412d-8620-f67256b72798
