### PR TITLE
fix: make icons use --primary-color

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -92,12 +92,7 @@ body .content {
 select,
 option,
 .icon {
-  color: var(--gray-00);
-}
-
-select[data-theme='dark'],
-option[data-theme='dark'] .icon[data-theme='dark'] {
-  color: var(--gray-00);
+  color: var(--primary-color);
 }
 
 /****** Sidebar ******/


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #160 

- - -
- Changed color icon to the `--primary-color`.
- Technically, the rule that's left, is not really needed to have icons look fine on both themes. I'm not entirely sure though from where, specific colors were being taken in such case.