### PR TITLE
fix: replace warning callout with caution

### DIFF
--- a/src/content/docs/devops.md
+++ b/src/content/docs/devops.md
@@ -237,7 +237,7 @@ You may send an email to `dev[at]freecodecamp.org` if you have any queries. As a
 
 ## Flight Manual - Server Maintenance
 
-:::warning
+:::caution
 
 1.  The guide applies to the **freeCodeCamp Staff members only**.
 2.  These instructions should not be considered exhaustive, please use caution.
@@ -316,7 +316,7 @@ No matter your choice of spinning resources, we have a few [handy cloud-init con
 You should keep the VMs up to date by performing updates and upgrades. This will
 ensure that the virtual machine is patched with the latest security fixes.
 
-:::warning
+:::caution
 Before you run these commands:
 
 - Make sure that the VM has been provisioned completely and that there are no
@@ -326,7 +326,7 @@ Before you run these commands:
   network bandwidth, memory and/or CPU usage spikes leading to outages on
   running applications.
 
-:::warning
+:::
 
 Update package information
 

--- a/src/content/docs/how-to-contribute-to-the-codebase.md
+++ b/src/content/docs/how-to-contribute-to-the-codebase.md
@@ -34,7 +34,7 @@ Follow these steps:
 
 2. Sync the latest changes from the freeCodeCamp upstream `main` branch to your `main` fork branch:
 
-:::warning
+:::caution
 If you have any outstanding pull requests that you made from the `main` branch of your fork, you will lose them at the end of this step.
 
 You should ensure your pull request is merged by a moderator before performing this step. To avoid this scenario, you should **always** work on a branch other than the `main`.

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
@@ -211,7 +211,7 @@ Follow these steps:
 
 2. Sync the latest changes from the upstream `main` branch to your local main branch:
 
-:::warning
+:::caution
 If you have any outstanding pull request that you made from the `main` branch of your fork, you will lose them at the end of this step.
 You should ensure your pull request is merged by a moderator before performing this step. To avoid this scenario, you should **always** work on a branch other than the `main`.
 :::

--- a/src/content/docs/how-to-work-on-tutorials-that-use-coderoad.md
+++ b/src/content/docs/how-to-work-on-tutorials-that-use-coderoad.md
@@ -18,7 +18,7 @@ Subsequent commit messages have to match the step number in `TUTORIAL.md` from t
 
 In order to make changes to commits on a version branch, you would need to rebase and edit the commits you want to change. This will rewrite the Git history, so we cannot accept PRs to these types of branches. Once a version branch is on the freeCodeCamp repo, it should never change.
 
-:::warning
+:::caution
 Never make or push changes to a version branch that is on one of the freeCodeCamp repos. Always create a new one
 :::
 
@@ -70,7 +70,7 @@ Also, keep in mind that instructions usually use the lessons around them for con
 
 ### Working on Version Branch
 
-:::warning
+:::caution
 Reminder: Never make or push changes to a version branch that is on one of the freeCodeCamp repos. Always create a new one
 :::
 
@@ -106,7 +106,7 @@ Before pushing a new version, view the new `feat/version-vX.X.Y` (will be merged
 
 If you have write access to the freeCodeCamp repo, have verified the `CHANGELOG` and `coderoad.yaml` files, have tested the changes using the instructions above, and want to push a new version of a tutorial:
 
-:::warning
+:::caution
 Reminder: Never make or push changes to a version branch that is on one of the freeCodeCamp repos. Always create a new one
 :::
 

--- a/src/content/docs/moderator-handbook.md
+++ b/src/content/docs/moderator-handbook.md
@@ -270,7 +270,7 @@ Camperbot serves as our moderation bot, and all of the commands use Discord's na
 
    All moderation commands will take a `reason` parameter, which should be a short explanation of why the action was taken. Moderation actions done with the bot will be logged in `#mod-actions`, which allows us all to stay on the same page. As such, we should avoid using Discord's built-in moderation tools, as they will not be logged.
 
-:::warning
+:::caution
 The reason provided to a moderation command will also be included in the DM notification to the camper. Please remember to be professional here.
 :::
 

--- a/src/content/docs/troubleshooting-development-issues.md
+++ b/src/content/docs/troubleshooting-development-issues.md
@@ -12,7 +12,7 @@ It is recommended to research your specific issue on resources such as Google, S
 
 If you are on a different OS or are still facing issues, see [getting help](#getting-help).
 
-:::warning
+:::caution
 Please avoid creating GitHub issues for problems with the prerequisite technologies. They are out of the scope of this project.
 :::
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- Starlight doesn't seem to have _Warning_ callout, instead used _Caution_ https://starlight.astro.build/guides/authoring-content/#asides.
- Alternatively, to more directly bring back the _Warning_ callout/aside, the _Caution_ could be used with a custom title: `:::caution[Warning]`, which would display _Warninig_ with the caution's icon https://starlight.astro.build/guides/authoring-content/#custom-aside-titles.