### PR TITLE
chore: use note aside for notes

### DIFF
--- a/src/content/docs/curriculum-file-structure.md
+++ b/src/content/docs/curriculum-file-structure.md
@@ -52,8 +52,14 @@ When renaming a certification, you will likely want to rename the associated sup
 1. In the YAML file, change the `title` to the new name.
 1. Rename the file and folder from step 3 for the rest of the curriculum languages.
 1. Update `client/src/redux/index.ts` to use the correct `title`.
-1. Optionally, update the `certSlug` for the superblock in the same file. **Note** that renaming a `certSlug` will change the URL for certifications and should only be done with careful consideration.
-1. Update the `title` in `client/src/resources/cert-and-project-map.ts` to the new value. **Note** that changing the `title` here **will break** the superBlock page for the associated certification. It relies on the superBlock title to match the certification title. You will likely want to rename the superBlock at the same time.
+1. Optionally, update the `certSlug` for the superblock in the same file.
+   :::note
+   Renaming a `certSlug` will change the URL for certifications and should only be done with careful consideration.
+   :::
+1. Update the `title` in `client/src/resources/cert-and-project-map.ts` to the new value.
+   :::note
+   Changing the `title` here **will break** the superBlock page for the associated certification. It relies on the superBlock title to match the certification title. You will likely want to rename the superBlock at the same time.
+   :::
 1. If you renamed the `certSlug` in step 7, change it here for the cert and all the nested `projects` values.
 1. In `shared/config/certification-settings.js`, update the value of `certTypeTitleMap` to the new name.
 1. If you renamed the `certSlug` in step 7, update the key of `certSlugTypeMap` in the same file.
@@ -74,7 +80,10 @@ Also, you will likely want to rename the certificate and the `{superBlock}-proje
 1. Rename the superblock folder in `client/src/pages/learn`.
 1. Update the `index.md` file in the above folder, changing the `title` and `superBlock` values to the new name.
 1. For each block folder within the above, update the `index.md` to use the correct `superBlock` value.
-1. In the `client/src/resources/cert-and-project-map.ts` file, update the path for the cert at the top of the file, and the `title` value for that superBlock. **Note** that changing the `title` here **will break** the ability to view the actual certification for this superBlock. It relies on the superBlock title to match the certification title. You will likely want to rename the certification at the same time.
+1. In the `client/src/resources/cert-and-project-map.ts` file, update the path for the cert at the top of the file, and the `title` value for that superBlock.
+   :::note
+   Changing the `title` here **will break** the ability to view the actual certification for this superBlock. It relies on the superBlock title to match the certification title. You will likely want to rename the certification at the same time.
+   :::
 1. Update the `superBlockCertTypeMap` key in `shared/config/certification-settings.js` to the new superBlock name.
 1. Update the path value in `client/src/assets/icons/index.tsx`.
 1. For each language in `client/i18n/locales`, update the `intro.json` file to use the new superBlock `dashedName`. In the English file, also update the `title`.

--- a/src/content/docs/how-to-enable-new-languages.md
+++ b/src/content/docs/how-to-enable-new-languages.md
@@ -65,7 +65,9 @@ You will need to add a step to the [`crowdin-download.client-ui.yml`](https://gi
     # dryrun_action: true
 ```
 
-Note that the `download_language` key needs to be set to the language code displayed on Crowdin.
+:::note
+The `download_language` key needs to be set to the language code displayed on Crowdin.
+:::
 
 ## Enabling a Language
 

--- a/src/content/docs/how-to-setup-freecodecamp-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.md
@@ -48,7 +48,7 @@ There are various ways to launch a Gitpod workspace:
 
 That's it, you can now skip to the 'syncing up from parent' section after you have launched a Gitpod workspace. Most parts of this guide applies to Gitpod workspaces, but be mindful of [how the URLs & Ports work within a Gitpod](https://www.gitpod.io/docs/configure/workspaces/ports) workspace.
 
-**Note: Troubleshooting port issues on Gitpod**
+#### Troubleshooting port issues on Gitpod
 
 Sometimes the service on port `8000` doesn't go live. This is common when you are restarting an inactive workspace.
 
@@ -168,7 +168,9 @@ Run these commands on your local machine:
 
 This will download the entire freeCodeCamp repository to your projects directory.
 
-Note: `--depth=1` creates a shallow clone of your fork, with only the most recent history/commit.
+:::note
+`--depth=1` creates a shallow clone of your fork, with only the most recent history/commit.
+:::
 
 ## Set up Syncing from Parent
 

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.md
@@ -86,7 +86,9 @@ Run these commands on your local machine:
 
 This will download the entire freeCodeCamp mobile repository to your projects directory.
 
-Note: `--depth=1` creates a shallow clone of your fork, with only the most recent history/commit.
+:::note
+`--depth=1` creates a shallow clone of your fork, with only the most recent history/commit.
+:::
 
 ## Set up Syncing from Parent
 

--- a/src/content/docs/how-to-translate-files.md
+++ b/src/content/docs/how-to-translate-files.md
@@ -237,7 +237,9 @@ The LearnToCode RPG runs on Ren'Py, which uses special syntax for translated str
 "[player_name]？好巧，我们的VIP队友{a=[vip_profile_url]}[player_name]{/a}会很高兴的。"
 ```
 
-Note: The `[]` and `{}` tags should be left intact.
+:::note
+The `[]` and `{}` tags should be left intact.
+:::
 
 ---
 
@@ -255,7 +257,9 @@ old "{icon=icon-fast-forward} Skip"
 new "{icon=icon-fast-forward} 跳过"
 ```
 
-Note: Again, the `new` prefix and the `{icon=icon-fast-forward}` tag should be left intact.
+:::note
+Again, the `new` prefix and the `{icon=icon-fast-forward}` tag should be left intact.
+:::
 
 ---
 
@@ -273,7 +277,9 @@ layla @ neutral "Hehe, [player_name], you are a fun one. I'm sure you will enjoy
 layla @ neutral "哈哈，[player_name]，你真有趣。我相信你一定会喜欢你的开发者工作的。"
 ```
 
-Note: `layla @ neutral` and `[player_name]` are left unchanged.
+:::note
+`layla @ neutral` and `[player_name]` are left unchanged.
+:::
 
 ---
 

--- a/src/content/docs/how-to-work-on-coding-challenges.md
+++ b/src/content/docs/how-to-work-on-coding-challenges.md
@@ -414,7 +414,9 @@ Use `parseInt` to convert the variable `realNumber` into an integer.
 - Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a new line that only has three backticks and **another empty line**. See example below:
 - Whitespace matters in Markdown, so we recommend that you make it visible in your editor.
 
-**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
+:::note
+If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
+:::
 
 The following is an example of code:
 
@@ -430,7 +432,9 @@ The following is an example of code:
 - If multiple notes are needed, then list all of the notes in separate sentences using the format: `**Notes:** First note text. Second note text.`
 - Use single quotes where applicable
 
-**Note:** The equivalent _Markdown_ should be used in place of _HTML_ tags.
+:::note
+The equivalent _Markdown_ should be used in place of _HTML_ tags.
+:::
 
 ## Writing tests
 

--- a/src/content/docs/how-to-work-on-practice-projects.md
+++ b/src/content/docs/how-to-work-on-practice-projects.md
@@ -28,7 +28,11 @@ This will take you to a list of steps for the project. If you are working on an 
 
 When you click on a step, you'll be taken to the editor. This is a basic text editor that offers syntax highlighting.
 
-After you have made your changes, click the `Save Changes` button to save your changes. You will get a browser alert letting you know that your changes are ready to commit. Note that you'll need to use `git` manually to stage and commit your files - this tool will not do that for you.
+After you have made your changes, click the `Save Changes` button to save your changes. You will get a browser alert letting you know that your changes are ready to commit.
+
+:::note
+You'll need to use `git` manually to stage and commit your files - this tool will not do that for you.
+:::
 
 ### Step Tools
 
@@ -83,7 +87,9 @@ pnpm run create-next-step
 
 A one-off script that automatically adds a specified number of steps. The challenge seed code for all steps created will be empty.
 
-**Note:** This script also runs [update-step-titles](#update-step-titles).
+:::note
+This script also runs [update-step-titles](#update-step-titles).
+:::
 
 #### How to Run the Script
 
@@ -98,7 +104,9 @@ pnpm run create-empty-steps X # where X is the number of steps to create.
 
 A one-off script that automatically adds a new step at a specified position, incrementing all subsequent steps (both their titles and in their meta.json). The challenge seed code will use the previous step's challenge seed code with the editable region markers (ERMs) removed.
 
-**Note:** This script also runs [update-step-titles](#update-step-titles).
+:::note
+This script also runs [update-step-titles](#update-step-titles).
+:::
 
 #### How to Run the Script
 
@@ -113,7 +121,9 @@ pnpm run insert-step X # where X is the position to insert the new step.
 
 A one-off script that deletes an existing step, decrementing all subsequent steps (both their titles and in their meta.json)
 
-**Note:** This script also runs [update-step-titles](#update-step-titles).
+:::note
+This script also runs [update-step-titles](#update-step-titles).
+:::
 
 #### How to Run the Script
 
@@ -171,7 +181,9 @@ If you have changed tests or seed code of the steps in a way that is not compati
 
 #### How to Run the Script
 
-**Note:** You need to have node and typescript installed globally.
+:::note
+You need to have node and typescript installed globally.
+:::
 
 1.  Be in the root directory
 2.  Run the following command

--- a/src/content/docs/moderator-handbook.md
+++ b/src/content/docs/moderator-handbook.md
@@ -286,7 +286,9 @@ The reason provided to a moderation command will also be included in the DM noti
 
    Our moderation bot is configured to log deleted messages automatically in the `#mod-actions` channel. If a message is not in line with our Code of Conduct, or otherwise not appropriate for our community, you are generally safe to delete it.
 
-   Note that if the message contains content that violates Discord's terms of service, you'll want to report it via https://dis.gd/report **prior to** deleting it.
+   :::note
+   If the message contains content that violates Discord's terms of service, you'll want to report it via https://dis.gd/report **prior to** deleting it.
+   :::
 
 5. **Don’t threaten to take action**
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- There were few occurrences of text marked as _Note_, that were not using the note aside/callout. This change makes them more prominent visually.
- `src/content/docs/curriculum-file-structure.md` has changes adding indentation with `3` spaces. Not sure what's up with that, but it's what prettier wanted and did when running `pnpm run format`.