### PR TITLE
fix: theme selection in mobile view

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -70,7 +70,8 @@ export default defineConfig({
       components: {
         // Override the default `SocialIcons` component.
         Header: './src/components/FCCHeader.astro',
-        ThemeProvider: './src/components/FCCThemeProvider.astro'
+        ThemeProvider: './src/components/FCCThemeProvider.astro',
+        ThemeSelect: './src/components/FCCThemeSelect.astro'
       },
       customCss: [
         // Relative path to your custom CSS file

--- a/src/components/FCCThemeProvider.astro
+++ b/src/components/FCCThemeProvider.astro
@@ -1,6 +1,8 @@
 ---
+import type { Theme } from '../theme';
+
 type Props = {
-  defaultTheme?: "auto" | "dark" | "light" | undefined;
+  defaultTheme?: Theme;
 };
 
 const { defaultTheme = "auto" } = Astro.props;

--- a/src/components/FCCThemeSelect.astro
+++ b/src/components/FCCThemeSelect.astro
@@ -1,71 +1,40 @@
 <theme-button>
-   <button class="theme-toggle" aria-label="Toggle Theme">💡</button>
+  <button class="theme-toggle" aria-label="Toggle Theme">💡</button>
 </theme-button>
 
-<script is:inline>
+<script>
+import type { ThemeChangeEvent, Theme } from '../theme';
 
-
+const theme = window.theme;
 class ThemeButton extends HTMLElement {
- constructor()
- {
-  super();
-  const button = this.querySelector('.theme-toggle');
-   if (button)
-   {
-        button.addEventListener('click', () =>
-        {
-           const currentTheme = theme.getTheme();
-           if(currentTheme == "light")
-           {
-             theme.setTheme("dark");
-           }
-           else if(currentTheme == "dark")
-           {
-              theme.setTheme("light");
-           }
-           else
-           {
-             const newTheme = matchMedia('(prefers-color-scheme: light)').matches ? 'dark' : 'light';
-              theme.setTheme(newTheme);
-           }
-           this.updateSelectedTheme();
+  constructor() {
+    super();
+    const button = this.querySelector('.theme-toggle');
+    if (!button) { return };
 
-        });
-      document.addEventListener("theme-changed", (event) => {
-        this.updateSelectedTheme(event.detail.theme);
-      });
-    }
+    button.addEventListener('click', () => {
+      const currentTheme = theme.getTheme();
+      let newTheme: Theme;
+      if (currentTheme == 'light') {
+        newTheme = 'dark';
+      } else if (currentTheme == 'dark') {
+        newTheme = 'light';
+      } else {
+        newTheme = matchMedia('(prefers-color-scheme: light)').matches ? 'dark' : 'light';
+        }
+      theme.setTheme(newTheme);
+      this.updateSelectedTheme(newTheme);
+
+    });
+    window.addEventListener("theme-changed", (event: ThemeChangeEvent) => {
+      this.updateSelectedTheme(event.detail.theme);
+    });
   }
-    updateSelectedTheme(newTheme = theme.getTheme())
-    {
-      this.querySelector(".theme-toggle").value = newTheme;
-    }
-
+  updateSelectedTheme(newTheme: Theme) {
+    (this.querySelector('.theme-toggle') as HTMLButtonElement).value = newTheme;
+  }
 }
-  /*
-  if (!customElements.get("theme-selector")) {
-    customElements.define(
-      "theme-selector",
-      class extends HTMLElement {
-        connectedCallback() {
-          this.querySelector("select").onchange = (event) =>
-            theme.setTheme(event.target.value);
-          this.setAttribute("aria-label", "Select Theme");
-          this.updateSelectedTheme();
-
-          document.addEventListener("theme-changed", (event) => {
-            this.updateSelectedTheme(event.detail.theme);
-          });
-        }
-
-        updateSelectedTheme(newTheme = theme.getTheme()) {
-          this.querySelector("select").value = newTheme;
-        }
-      }
-    );
-
-  }*/
- customElements.define('theme-button', ThemeButton);
+customElements.define('theme-button', ThemeButton);
 </script>
 
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,13 @@
+export type Theme = 'auto' | 'light' | 'dark';
+
+export class ThemeChangeEvent extends CustomEvent<{
+  theme: Theme;
+  systemTheme: 'light' | 'dark';
+  defaultTheme: string;
+}> {}
+
+declare global {
+  interface WindowEventMap {
+    'theme-changed': ThemeChangeEvent;
+  }
+}


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #191 

- - -
- Fixes theme selecting in mobile view. To be exact, now the same component is used as in _normal_ view.
- Completes replacing Starlight's `ThemeSelect` component with custom component. Until now it was replaced only in the custom _FCCHeader_ component.
- This required changing _FCCThemeSelect_ to allow it to be used multiple times. While doing that there appeared couple typing issues, which needed some juggling around.
- As a side note, that _nullish coalescing assignment (??=)_ operator in _FCCThemeProvider_ component was surprising as heck.