### PR TITLE
fix: update MongoDB version from 5.0.x to 6.0.x in documentation

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -84,7 +84,7 @@ We primarily support development on Linux and Unix-based systems like Ubuntu and
 | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
 | [Node.js](http://nodejs.org)                                                                  | `20.x`  | We use the "Active LTS" version, See [LTS Schedule](https://nodejs.org/en/about/releases/). |
 | [pnpm](https://pnpm.io/installation)                                                          | `9.x`   | -                                                                                           |
-| [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `5.0.x` | -                                                                                           |
+| [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `6.0.x` | -                                                                                           |
 
 :::danger
 If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting section](/troubleshooting-development-issues) for details.


### PR DESCRIPTION
This is to address issue: https://github.com/freeCodeCamp/freeCodeCamp/issues/55511 which speaks of the current MongoDB version from 5.0.x to 6.0.x.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#55511](https://github.com/freeCodeCamp/freeCodeCamp/issues/55511)

<!-- Feel free to add any additional description of changes below this line -->
