### PR TITLE
fix: cut off logo

### DIFF
--- a/src/components/FCCHeader.astro
+++ b/src/components/FCCHeader.astro
@@ -52,11 +52,12 @@ const shouldRenderSearch = true;
   .title-wrapper {
     /* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
     overflow: hidden;
+    margin: auto;
   }
 
   .title-wrapper > img {
-    min-width: 10rem;
-    max-width: 40%;
+    height: 24px;
+    width: 210px;
   }
 
   .right-group,
@@ -105,10 +106,6 @@ const shouldRenderSearch = true;
         /* 3 (right items): use the space that these need. */
         auto;
       align-content: center;
-    }
-    .title-wrapper > img {
-      min-width: 15rem;
-      max-width: 40%;
     }
   }
 </style>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #287

- - -
- Fixes logo being cut off.
- The size of logo is now static - 210 x 24 - consistent with size on forums and main page.