### PR TITLE
fix: search icon not visible in light theme mobile view

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -157,6 +157,12 @@ body .content {
   background-color: var(--theme-color);
 }
 
+@media (max-width: 50em) {
+  [data-theme='light'] button[data-open-modal] {
+    color: var(--sl-color-black);
+  }
+}
+
 select,
 option,
 .icon {


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- In mobile view, on light theme, search icon in the header had dark color. This change makes it white (despite of the starlight var name).