### PR TITLE
refactor: sidebar links

### DIFF
--- a/src/components/FCCSidebar.astro
+++ b/src/components/FCCSidebar.astro
@@ -6,218 +6,195 @@ import { getEntry } from 'astro:content';
 const entry = await getEntry('i18n', Astro.currentLocale ?? '');
 const prefix = Astro.currentLocale == 'en' ? '' : Astro.currentLocale;
 const { nested } = Astro.props;
+
+interface Section {
+  title: string;
+  contents: {
+    href: string;
+    title: string;
+    strong?: boolean;
+  }[];
+  addSeparator?: boolean;
+}
+
+const content: Section[] = [
+  {
+    title: 'sidebar.gettingStarted',
+    contents: [
+      { href: '/index', title: 'sidebar.introduction' },
+      { href: '/FAQ', title: 'sidebar.faq' },
+      { href: '/security', title: 'sidebar.report_vulnerability' }
+    ]
+  },
+  {
+    title: 'sidebar.translation_contribution',
+    contents: [
+      { href: '/how-to-translate-files', title: 'sidebar.translate_resources' },
+      {
+        href: '/how-to-proofread-files',
+        title: 'sidebar.proofread_translations'
+      }
+    ]
+  },
+  {
+    title: 'sidebar.code_contribution',
+    contents: [
+      {
+        href: '/how-to-setup-freecodecamp-locally',
+        title: 'sidebar.setup_freecodecamp'
+      },
+      { href: '/codebase-best-practices', title: 'sidebar.best_practices' },
+      {
+        href: '/how-to-contribute-to-the-codebase',
+        title: 'sidebar.work_on_codebase'
+      },
+      {
+        href: '/how-to-work-on-coding-challenges',
+        title: 'sidebar.work_on_coding_challenges'
+      },
+      { href: '/curriculum-help', title: 'sidebar.use_the_curriculum_helpers' },
+      {
+        href: '/how-to-work-on-the-component-library',
+        title: 'sidebar.work_on_component_library'
+      },
+      {
+        href: '/how-to-work-on-practice-projects',
+        title: 'sidebar.work_on_practice_projects'
+      },
+      {
+        href: '/how-to-setup-freecodecamp-mobile-app-locally',
+        title: 'sidebar.work_on_mobile_app'
+      },
+      {
+        href: '/how-to-work-on-tutorials-that-use-coderoad',
+        title: 'sidebar.coderoad'
+      },
+      {
+        href: '/how-to-work-on-localized-client-webapp',
+        title: 'sidebar.work_on_webapp'
+      },
+      {
+        href: '/how-to-add-playwright-tests',
+        title: 'sidebar.work_on_playwright_tests'
+      },
+      {
+        href: '/how-to-help-with-video-challenges',
+        title: 'sidebar.work_on_video_challenges'
+      },
+      {
+        href: '/how-to-work-on-the-docs-theme',
+        title: 'sidebar.work_on_documentation'
+      },
+      {
+        href: '/how-to-open-a-pull-request',
+        title: 'sidebar.open_a_pull_request'
+      }
+    ]
+  },
+  {
+    title: 'sidebar.additional_guides',
+    contents: [
+      { href: '/curriculum-file-structure', title: 'sidebar.file_structure' },
+      {
+        href: '/how-to-catch-outgoing-emails-locally',
+        title: 'sidebar.debug_outgoing_emails_locally'
+      },
+      { href: '/how-to-setup-wsl', title: 'sidebar.setup_fcc_on_wsl' },
+      {
+        href: '/how-to-use-docker-on-windows-home',
+        title: 'sidebar.docker_on_windows_home'
+      },
+      { href: '/user-token-workflow', title: 'sidebar.user_token_workflow' },
+      {
+        href: '/troubleshooting-development-issues',
+        title: 'sidebar.troubleshooting_development_issues'
+      },
+      {
+        href: '/authors-analytics-manual',
+        title: 'sidebar.authors_analytics_manual'
+      }
+    ]
+  },
+  {
+    title: 'sidebar.flight_manuals',
+    addSeparator: true,
+    contents: [
+      { href: '/moderator-handbook', title: 'sidebar.moderator_handbook' },
+      { href: '/reply-templates', title: 'sidebar.reply_templates' },
+      {
+        href: '/language-lead-handbook',
+        title: 'sidebar.language_lead_handbook'
+      },
+      { href: '/devops', title: 'sidebar.devops_handbook' },
+      {
+        href: '/courses-vscode-extension',
+        title: 'sidebar.courses_vscode_extension'
+      },
+      {
+        href: '/how-to-enable-new-languages',
+        title: 'sidebar.enable_new_language'
+      }
+    ]
+  },
+  {
+    title: 'sidebar.our_community',
+    addSeparator: true,
+    contents: [
+      {
+        href: 'https://github.com/freecodecamp/freecodecamp',
+        title: 'sidebar.github',
+        strong: true
+      },
+      {
+        href: 'https://freecodecamp.org/forum/c/contributors',
+        title: 'sidebar.discourse_forum',
+        strong: true
+      },
+      {
+        href: 'https://discord.gg/PRyKn3Vbay',
+        title: 'sidebar.chat_server',
+        strong: true
+      }
+    ]
+  }
+];
 ---
 
 <nav class:list={{ 'top-level': !nested }}>
   <ul>
-    <li>
-      <strong>{entry?.data['sidebar.gettingStarted']}</strong>
-      <ul>
-        <li>
-          <a
-            href={`${prefix}/index`}
-            title={entry?.data['sidebar.introduction']}
-            >{entry?.data['sidebar.introduction']}</a
-          >
-        </li>
-        <li><a href={`${prefix}/FAQ`}>{entry?.data['sidebar.faq']}</a></li>
-        <li>
-          <a href={`${prefix}/security`}
-            >{entry?.data['sidebar.report_vulnerability']}</a
-          >
-        </li>
-      </ul>
-    </li>
-    <li>
-      <strong>{entry?.data['sidebar.translation_contribution']}</strong>
-      <ul>
-        <li>
-          <a href={`${prefix}/how-to-translate-files`}>
-            {entry?.data['sidebar.translate_resources']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-proofread-files`}
-            >{entry?.data['sidebar.proofread_translations']}</a
-          >
-        </li>
-      </ul>
-    </li>
-    <li>
-      <strong>{entry?.data['sidebar.code_contribution']}</strong>
-      <ul>
-        <li>
-          <a href={`${prefix}/how-to-setup-freecodecamp-locally`}
-            >{entry?.data['sidebar.setup_freecodecamp']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/codebase-best-practices`}
-            >{entry?.data['sidebar.best_practices']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-contribute-to-the-codebase`}
-            >{entry?.data['sidebar.work_on_codebase']}</a
-          >
-        </li>
-
-        <li>
-          <a href={`${prefix}/how-to-work-on-coding-challenges`}
-            >{entry?.data['sidebar.work_on_coding_challenges']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/curriculum-help`}
-            >{entry?.data['sidebar.use_the_curriculum_helpers']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-work-on-the-component-library`}
-            >{entry?.data['sidebar.work_on_component_library']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-work-on-practice-projects`}
-            >{entry?.data['sidebar.work_on_practice_projects']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-setup-freecodecamp-mobile-app-locally`}
-            >{entry?.data['sidebar.work_on_mobile_app']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-work-on-tutorials-that-use-coderoad`}
-            >{entry?.data['sidebar.coderoad']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-work-on-localized-client-webapp`}
-            >{entry?.data['sidebar.work_on_webapp']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-add-playwright-tests`}
-            >{entry?.data['sidebar.work_on_playwright_tests']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-help-with-video-challenges`}
-            >{entry?.data['sidebar.work_on_video_challenges']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-work-on-the-docs-theme`}
-            >{entry?.data['sidebar.work_on_documentation']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-open-a-pull-request`}
-            >{entry?.data['sidebar.open_a_pull_request']}</a
-          >
-        </li>
-      </ul>
-    </li>
-    <li>
-      <strong>{entry?.data['sidebar.additional_guides']}</strong><ul>
-        <li>
-          <a href={`${prefix}/curriculum-file-structure`}
-            >{entry?.data['sidebar.file_structure']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-catch-outgoing-emails-locally`}
-            >{entry?.data['sidebar.debug_outgoing_emails_locally']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-setup-wsl`}
-            >{entry?.data['sidebar.setup_fcc_on_wsl']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-use-docker-on-windows-home`}
-            >{entry?.data['sidebar.docker_on_windows_home']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/user-token-workflow`}
-            >{entry?.data['sidebar.user_token_workflow']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/troubleshooting-development-issues`}
-            >{entry?.data['sidebar.troubleshooting_development_issues']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/authors-analytics-manual`}
-            >{entry?.data['sidebar.authors_analytics_manual']}</a
-          >
-        </li>
-      </ul>
-    </li>
-  </ul>
-  <hr />
-  <ul>
-    <li>
-      <strong>{entry?.data['sidebar.flight_manuals']}</strong>
-      <ul>
-        <li>
-          <a href={`${prefix}/moderator-handbook`}
-            >{entry?.data['sidebar.moderator_handbook']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/reply-templates`}
-            >{entry?.data['sidebar.reply_templates']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/language-lead-handbook`}
-            >{entry?.data['sidebar.language_lead_handbook']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/devops`}
-            >{entry?.data['sidebar.devops_handbook']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/courses-vscode-extension`}
-            >{entry?.data['sidebar.courses_vscode_extension']}</a
-          >
-        </li>
-        <li>
-          <a href={`${prefix}/how-to-enable-new-languages`}
-            >{entry?.data['sidebar.enable_new_language']}</a
-          >
-        </li>
-      </ul>
-    </li>
-  </ul>
-  <hr />
-  <ul>
-    <li>
-      <strong>{entry?.data['sidebar.our_community']}</strong><ul>
-        <li>
-          <a href='https://github.com/freecodecamp/freecodecamp'
-            ><strong>{entry?.data['sidebar.github']}</strong></a
-          >
-        </li>
-        <li>
-          <a href='https://freecodecamp.org/forum/c/contributors'
-            ><strong>{entry?.data['sidebar.discourse_forum']}</strong></a
-          >
-        </li>
-        <li>
-          <a href='https://discord.gg/PRyKn3Vbay'
-            ><strong>{entry?.data['sidebar.chat_server']}</strong></a
-          >
-        </li>
-      </ul>
-    </li>
+    {
+      content.map(
+        ({ title, contents, addSeparator = false }) =>
+          title && (
+            <>
+              {addSeparator && <hr />}
+              <li>
+                <strong>{entry?.data[title]}</strong>
+                <ul>
+                  {contents &&
+                    contents.map(
+                      item =>
+                        item.title && (
+                          <li>
+                            <a
+                              href={`${prefix}${item.href}`}
+                              title={entry?.data[item.title]}
+                            >
+                              {item.strong ? (
+                                <strong>{entry?.data[item.title]}</strong>
+                              ) : (
+                                entry?.data[item.title]
+                              )}
+                            </a>
+                          </li>
+                        )
+                    )}
+                </ul>
+              </li>
+            </>
+          )
+      )
+    }
   </ul>
 </nav>
 <div class='md:sl-hidden'>

--- a/src/components/FCCSidebar.astro
+++ b/src/components/FCCSidebar.astro
@@ -1,17 +1,17 @@
 ---
 import type { Props } from '@astrojs/starlight/props';
 import MobileMenuFooter from '@astrojs/starlight/components/MobileMenuFooter.astro';
-import { getEntry } from 'astro:content';
+import { type CollectionEntry, getEntry } from 'astro:content';
 
 const entry = await getEntry('i18n', Astro.currentLocale ?? '');
 const prefix = Astro.currentLocale == 'en' ? '' : Astro.currentLocale;
 const { nested } = Astro.props;
 
 interface Section {
-  title: string;
+  title: keyof CollectionEntry<'i18n'>['data'];
   contents: {
     href: string;
-    title: string;
+    title: keyof CollectionEntry<'i18n'>['data'];
     strong?: boolean;
   }[];
   addSeparator?: boolean;


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- Refactoring to make modifying sidebar less daunting.
- ~~There are some type complaints regarding ie. `entry?.data[title]`, which doesn't prevent rendering:~~
> ~~Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ 'skipLink.label'?: string | undefined; 'search.label'?: string | undefined; 'search.ctrlKey'?: string | undefined; 'search.cancelLabel'?: string | undefined; 'search.devWarning'?: string | undefined; ... 34 more ...; 'expressiveCode.terminalWindowFallbackTitle'?: string | undefined; } & { ...; }'.
  No index signature with a parameter of type 'string' was found on type '{ 'skipLink.label'?: string | undefined; 'search.label'?: string | undefined; 'search.ctrlKey'?: string | undefined; 'search.cancelLabel'?: string | undefined; 'search.devWarning'?: string | undefined; ... 34 more ...; 'expressiveCode.terminalWindowFallbackTitle'?: string | undefined; } & { ...; }'.ts(7053)~~

- `title`s in sidebar are typed against i18n keys 🙆‍♂️ 