### PR TITLE
fix: landing and getting started

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,10 +42,7 @@ export default defineConfig({
         ThemeSelect: './src/components/FCCThemeSelect.astro',
         Sidebar: './src/components/FCCSidebar.astro'
       },
-      customCss: [
-        // Relative path to your custom CSS file
-        './src/styles/tailwind.css'
-      ]
+      customCss: ['./src/styles/tailwind.css']
     }),
     tailwind()
   ],

--- a/src/components/FCCHeader.astro
+++ b/src/components/FCCHeader.astro
@@ -22,13 +22,10 @@ const shouldRenderSearch = true;
   <a
     class='title-wrapper sl-flex'
     data-nosearch=''
-    href='/'
+    href='/intro'
     style='justify-content:center'
   >
-    <img
-      alt='freeCodeCamp.org'
-      src='https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg'
-    />
+    <img alt='freeCodeCamp.org' class='fcc-logo' />
   </a>
 
   <div class='sl-hidden md:sl-flex right-group'>
@@ -55,9 +52,10 @@ const shouldRenderSearch = true;
     margin: auto;
   }
 
-  .title-wrapper > img {
+  .title-wrapper > .fcc-logo {
     height: 24px;
     width: 210px;
+    content: var(--fcc-logo);
   }
 
   .right-group,
@@ -107,5 +105,13 @@ const shouldRenderSearch = true;
         auto;
       align-content: center;
     }
+  }
+
+  :root {
+    --fcc-logo: url('https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg');
+  }
+
+  :root[data-theme='light'] {
+    --fcc-logo: url('https://cdn.freecodecamp.org/platform/universal/fcc_secondary.svg');
   }
 </style>

--- a/src/components/FCCSidebar.astro
+++ b/src/components/FCCSidebar.astro
@@ -19,9 +19,9 @@ interface Section {
 
 const content: Section[] = [
   {
-    title: 'sidebar.gettingStarted',
+    title: 'sidebar.introduction',
     contents: [
-      { href: '/index', title: 'sidebar.introduction' },
+      { href: '/getting-started', title: 'sidebar.gettingStarted' },
       { href: '/FAQ', title: 'sidebar.faq' },
       { href: '/security', title: 'sidebar.report_vulnerability' }
     ]

--- a/src/components/FCCThemeSelect.astro
+++ b/src/components/FCCThemeSelect.astro
@@ -1,5 +1,15 @@
 <theme-button>
-  <button class='theme-toggle' aria-label='Toggle Theme'>💡</button>
+  <button class='theme-toggle' aria-label='Toggle Theme'>
+    <span class='theme-option auto'>
+      <span class='theme-icon'>🌓</span> Auto
+    </span>
+    <span class='theme-option light'>
+      <span class='theme-icon'>☀️</span> Light
+    </span>
+    <span class='theme-option dark'>
+      <span class='theme-icon'>🌙</span> Dark
+    </span>
+  </button>
 </theme-button>
 
 <script>
@@ -10,32 +20,31 @@
     constructor() {
       super();
       const button = this.querySelector('.theme-toggle');
-      if (!button) {
-        return;
-      }
+      if (!button) return;
 
       button.addEventListener('click', () => {
         const currentTheme = theme.getTheme();
         let newTheme: Theme;
-        if (currentTheme == 'light') {
-          newTheme = 'dark';
-        } else if (currentTheme == 'dark') {
-          newTheme = 'light';
-        } else {
-          newTheme = matchMedia('(prefers-color-scheme: light)').matches
-            ? 'dark'
-            : 'light';
-        }
+        if (currentTheme === 'auto') newTheme = 'light';
+        else if (currentTheme === 'light') newTheme = 'dark';
+        else newTheme = 'auto';
+
         theme.setTheme(newTheme);
         this.updateSelectedTheme(newTheme);
       });
+
       window.addEventListener('theme-changed', (event: ThemeChangeEvent) => {
         this.updateSelectedTheme(event.detail.theme);
       });
+
+      this.updateSelectedTheme(theme.getTheme());
     }
+
     updateSelectedTheme(newTheme: Theme) {
-      (this.querySelector('.theme-toggle') as HTMLButtonElement).value =
-        newTheme;
+      const button = this.querySelector('.theme-toggle') as HTMLButtonElement;
+      button.value = newTheme;
+      button.classList.remove('auto-theme', 'light-theme', 'dark-theme');
+      button.classList.add(`${newTheme}-theme`);
     }
   }
   customElements.define('theme-button', ThemeButton);
@@ -44,5 +53,26 @@
 <style>
   .theme-toggle {
     background-color: var(--tertiary-background);
+    border: none;
+    cursor: pointer;
+    padding: 5px 10px;
+    border-radius: 15px;
+    display: flex;
+    align-items: center;
+  }
+
+  .theme-option {
+    display: none;
+  }
+
+  .auto-theme .theme-option.auto,
+  .light-theme .theme-option.light,
+  .dark-theme .theme-option.dark {
+    display: flex;
+    align-items: center;
+  }
+
+  .theme-icon {
+    margin-right: 5px;
   }
 </style>

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -1,0 +1,51 @@
+---
+title: Getting Started
+---
+
+The [freeCodeCamp.org](https://freecodecamp.org) community is possible thanks to thousands of kind volunteers like you. If you want to contribute your time and expertise, we would be excited to welcome you aboard.
+
+:::note
+Before you proceed, please take a quick 2 minutes to read our [Code of Conduct](https://www.freecodecamp.org/code-of-conduct). We strictly enforce it across our community so that contributing to freeCodeCamp.org is a safe, inclusive experience for everyone.
+:::
+
+You are welcome to create, update and fix bugs in our [curriculum](#curriculum), help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform), or [help us translate](#translations) freeCodeCamp.org to world languages.
+
+We answer the most common questions about contributing [in our contributor FAQ](/faq).
+
+Happy contributing.
+
+---
+
+## Curriculum
+
+Our curriculum is curated by the global freeCodeCamp community. This way, we are able to incorporate expert knowledge from volunteers like you.
+
+You can help expand and improve the curriculum. You can also update project user stories to better-explain concepts. And you can improve our automated tests so that we can more accurately test people's code.
+
+**If you're interested in improving our curriculum, here's [how to contribute to the curriculum](/how-to-work-on-coding-challenges).**
+
+## Translations
+
+We are localizing freeCodeCamp.org to major world languages.
+
+Certifications are already live in some major world languages like below:
+
+- [Chinese (中文)](https://www.freecodecamp.org/chinese/learn)
+- [Spanish (Español)](https://www.freecodecamp.org/espanol/learn)
+- [Italian (Italiano)](https://www.freecodecamp.org/italian/learn)
+- [Portuguese (Português)](https://www.freecodecamp.org/portuguese/learn)
+- [Ukrainian (Українська)](https://www.freecodecamp.org/ukrainian/learn)
+- [Japanese (日本語)](https://www.freecodecamp.org/japanese/learn)
+- [German (Deutsch)](https://www.freecodecamp.org/german/learn)
+
+We encourage you to read the [announcement here](https://www.freecodecamp.org/news/help-translate-freecodecamp-language/) and share it with your friends to get them excited about this.
+
+**If you're interested in translating, here's [how to translate freeCodeCamp's resources](/how-to-translate-files).**
+
+## Learning Platform
+
+Our learning platform runs on a modern JavaScript stack. It has various components, tools, and libraries. These include Node.js, MongoDB, OAuth 2.0, React, Gatsby, Webpack, and more.
+
+Broadly, we have a Node.js based API server, a set of React-based client applications, testing scripts to evaluate camper-submitted curriculum projects, and more. If you want to productively contribute to the learning platform, we recommend some familiarity with these tools.
+
+**If you want to help us improve our codebase here's [how to set up freeCodeCamp](/how-to-setup-freecodecamp-locally).**

--- a/src/content/docs/intro.mdx
+++ b/src/content/docs/intro.mdx
@@ -3,14 +3,14 @@ title: Contribute to the freeCodeCamp Community
 description: Help us make freeCodeCamp better for everyone.
 template: splash
 hero:
-  tagline:
-    This community is possible thanks to thousands of kind volunteers like you.
-    Help us make freeCodeCamp better for everyone.
+  tagline: This community is possible thanks to thousands of kind volunteers like you.
   actions:
     - text: Get Started
-      link: /intro#getting-started
+      link: /getting-started
       icon: right-arrow
       variant: primary
+prev: false
+next: false
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
@@ -28,60 +28,11 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     built by campers.
   </Card>
   <Card title='Translations' icon='translate'>
-    [Help us translate](/intro#translations) freeCodeCamp.org's resources.
+    [Help us translate](/getting-started#translations) freeCodeCamp.org's
+    resources.
   </Card>
   <Card title='Open Source' icon='github'>
-    [Contribute to our open-source codebase](/intro#learning-platform) on
-    GitHub.
+    [Contribute to our open-source codebase](/getting-started#learning-platform)
+    on GitHub.
   </Card>
 </CardGrid>
-
-## Getting Started
-
-The [freeCodeCamp.org](https://freecodecamp.org) community is possible thanks to thousands of kind volunteers like you. If you want to contribute your time and expertise, we would be excited to welcome you aboard.
-
-:::note
-Before you proceed, please take a quick 2 minutes to read our [Code of Conduct](https://www.freecodecamp.org/code-of-conduct). We strictly enforce it across our community so that contributing to freeCodeCamp.org is a safe, inclusive experience for everyone.
-:::
-
-You are welcome to create, update and fix bugs in our [curriculum](#curriculum), help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform), or [help us translate](#translations) freeCodeCamp.org to world languages.
-
-We answer the most common questions about contributing [in our contributor FAQ](/faq).
-
-Happy contributing.
-
----
-
-## Curriculum
-
-Our curriculum is curated by the global freeCodeCamp community. This way, we are able to incorporate expert knowledge from volunteers like you.
-
-You can help expand and improve the curriculum. You can also update project user stories to better-explain concepts. And you can improve our automated tests so that we can more accurately test people's code.
-
-**If you're interested in improving our curriculum, here's [how to contribute to the curriculum](/how-to-work-on-coding-challenges).**
-
-## Translations
-
-We are localizing freeCodeCamp.org to major world languages.
-
-Certifications are already live in some major world languages like below:
-
-- [Chinese (中文)](https://www.freecodecamp.org/chinese/learn)
-- [Spanish (Español)](https://www.freecodecamp.org/espanol/learn)
-- [Italian (Italiano)](https://www.freecodecamp.org/italian/learn)
-- [Portuguese (Português)](https://www.freecodecamp.org/portuguese/learn)
-- [Ukrainian (Українська)](https://www.freecodecamp.org/ukrainian/learn)
-- [Japanese (日本語)](https://www.freecodecamp.org/japanese/learn)
-- [German (Deutsch)](https://www.freecodecamp.org/german/learn)
-
-We encourage you to read the [announcement here](https://www.freecodecamp.org/news/help-translate-freecodecamp-language/) and share it with your friends to get them excited about this.
-
-**If you're interested in translating, here's [how to translate freeCodeCamp's resources](/how-to-translate-files).**
-
-## Learning Platform
-
-Our learning platform runs on a modern JavaScript stack. It has various components, tools, and libraries. These include Node.js, MongoDB, OAuth 2.0, React, Gatsby, Webpack, and more.
-
-Broadly, we have a Node.js based API server, a set of React-based client applications, testing scripts to evaluate camper-submitted curriculum projects, and more. If you want to productively contribute to the learning platform, we recommend some familiarity with these tools.
-
-**If you want to help us improve our codebase here's [how to set up freeCodeCamp](/how-to-setup-freecodecamp-locally).**


### PR DESCRIPTION
This PR addresses a rather peculiar thing about the enty-points:

- We have a `pages/index.astro` which we abuse to do client side redirects for the legacy docsify links that frustratingly used [URI fragments](https://developer.mozilla.org/en-US/docs/Web/URI/Fragment) which can't be redirected from server side.
- We created the `intro.mdx` which could then serve as the landing page - but it limited the exposure to the sidebar and the collection of content we have.

So, this PR adds another getting-started page. This makes it slightly nicer because index.astro --> intro.mdx and then a user's action takes them to the getting-started for nicer conversion.

I touched up the theme selector while I was there.

