### PR TITLE
fix link on how to work on documentation page

### DIFF
--- a/src/content/docs/how-to-work-on-the-docs-theme.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-theme.mdx
@@ -32,7 +32,7 @@ When you work on translating docs on Crowdin, make sure to replace the `#target-
 :::note
 A quick reminder that you do not need to set up anything for working on the content for the documentation site.
 
-To work on the contributing guidelines, see [work on the docs content](#work-on-the-docs-content) section.
+To work on the contributing guidelines, see [work on the content of the docs](#work-on-the-content-of-the-docs) section.
 
 :::
 


### PR DESCRIPTION
Checklist:


- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Fixes up a broken link on the [How to Work on Documentation](https://contribute.freecodecamp.org/how-to-work-on-the-docs-theme/) page

Broken Link
![broken](https://github.com/user-attachments/assets/ca7807f2-d1bd-4bb5-b593-f3d368ea40a3)


Existing ID
![Capture](https://github.com/user-attachments/assets/74abfcf4-2c4c-43cb-b5d6-84d960698619)

