### PR TITLE
fix: show emoji form instead of the markdown form

### DIFF
--- a/src/content/docs/how-to-open-a-pull-request.mdx
+++ b/src/content/docs/how-to-open-a-pull-request.mdx
@@ -113,7 +113,7 @@ Some examples of good PR titles would be:
 
 ## Feedback on Pull Requests
 
-> :tada: Congratulations on making a PR and thanks a lot for taking the time to contribute.
+> 🎉 Congratulations on making a PR and thanks a lot for taking the time to contribute.
 
 Our moderators will now take a look and leave you feedback. Please be patient with the fellow moderators and respect their time. All pull requests are reviewed in due course.
 

--- a/src/content/docs/security-hall-of-fame.mdx
+++ b/src/content/docs/security-hall-of-fame.mdx
@@ -11,4 +11,4 @@ While we do not offer any bounties or swags at the moment, we are grateful to th
 - Laurence Tennant ([@hyperreality](https://github.com/hyperreality)) working with IncludeSecurity.com - [GHSA-cc3r-grh4-27gj](https://github.com/freeCodeCamp/freeCodeCamp/security/advisories/GHSA-cc3r-grh4-27gj)
 - Michal Biesiada ([@mbiesiad](https://github.com/mbiesiad)) - [GHSA-6c37-r62q-7xf4](https://github.com/freeCodeCamp/freeCodeCamp/security/advisories/GHSA-6c37-r62q-7xf4)
 
-> **Thank you for your contributions :pray:**
+> **Thank you for your contributions 🙏**


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Fixes the markdown emoji issue on the [How to open a Pull Request (PR)](https://contribute.freecodecamp.org/how-to-open-a-pull-request/) page

**Issue**
![issue](https://github.com/user-attachments/assets/3254c86b-649f-4d9b-9d1b-8d24d253f17b)


<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
**Fix**
![tada](https://github.com/user-attachments/assets/8e2aa586-0b40-4011-883d-f7c7a7747292)
