### PR TITLE
chore: describe `ast_helpers` exposed in Python challenges

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -197,6 +197,25 @@ To check the return value of `__str__` you would write:
 });
 ```
 
+AST-based helpers are also exposed in the Python challenges in `ast_helpers` module. `_Node` class corresponds to the `ast_helpers.Node`:
+
+```py
+import ast_helpers
+
+code = '''
+class Spam:
+  def __str__(self):
+    return 'spam!'
+'''
+
+print(
+    ast_helpers.Node(code)
+    .find_class("Spam")
+    .find_function("__str__")
+    .has_return("'spam!'")
+)
+```
+
 ### Methods
 
 The exstensive list of methods for parsing and testing Python code is available [here](https://opensource.freecodecamp.org/curriculum-helpers/python.html#ast-based-helpers)


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- Not sure if it's clear `ast_helpers` module in challenges is not an alternate way to write test, but convenience for writing/debugging the ast part of the test.