### PR TITLE
docs: fix link to docs directory

### DIFF
--- a/src/content/docs/how-to-work-on-the-docs-theme.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-theme.mdx
@@ -4,7 +4,7 @@ title: How to Work on Documentation
 
 ## Work on the Content of the Docs
 
-To work on the contributing guidelines, you can edit or add files in the `docs` directory [available here](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/docs). When your changes are merged, they will be made available automatically at the documentation site.
+To work on the contributing guidelines, you can edit or add files in the `docs` directory [available here](https://github.com/freeCodeCamp/contribute/tree/main/src/content/docs). When your changes are merged, they will be made available automatically at the documentation site.
 
 When adding a new file to the `docs` directory, you should evaluate if the file should also be added to the sidebar navigation. We typically create a link in the [`_sidebar.md`](_sidebar) file for new and independent guides. Alternatively, You may follow the instructions below on creating an internal link for supporting guides.
 


### PR DESCRIPTION
Checklist:

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Ref #81

