### PR TITLE
chore: remove unnecessary quotes

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -466,7 +466,7 @@ You only need to follow this section if you're modifying the challenge test runn
 9. Update the test file to use the challenge data JSON file:
 
    ```bash
-   sed -i '' 's/..\/..\/shared\/config\/curriculum.json/.\/curriculum.json/g' test/widget_test.dart
+   sed -i 's/..\/..\/shared\/config\/curriculum.json/.\/curriculum.json/g' test/widget_test.dart
    ```
 
 10. Generate the challenge files:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
While following the instructions for the mobile app, I kept running into a problem. The console kept giving me the following: `sed: can't read s/..\/..\/shared\/config\/curriculum.json/.\/curriculum.json/g: No such file or directory` 

I have reason to suspect that it was trying to read ` s/..\/..\/shared\/config\/curriculum.json/.\/curriculum.json/g` as the file instead of the pattern. This should make the instructions work. 