### PR TITLE
docs(faq.mdx) : Fixed Grammatical Error in Frequently Asked Questions document 

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -9,7 +9,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 ### I am new to GitHub and Open Source. Where should I start?
 
-Check out our [How to Contribute to Open Source Guide](https://github.com/freeCodeCamp/how-to-contribute-to-open-source). It’s a great resource for beginners and includes tips on contributing to open-source projects.
+Check out our [How to Contribute to Open Source Guide](https://github.com/freeCodeCamp/how-to-contribute-to-open-source). It’s a great resource for beginners and include tips on contributing to open-source projects.
 
 ### What do I need to know to contribute to the codebase?
 


### PR DESCRIPTION
I have fixed a **grammatical** mistake in this document.  In the first question titled as **I am new to GitHub and Open Source. Where should I start?**, the answer has a grammatical typo. 

The typo is -:

`includes tips on contributing to open-source projects`

The fixed sentence is -:

`include tips on contributing to open-source projects`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
