### PR TITLE
fix: remove prettier-ignore line from curriculum-file-structure

### DIFF
--- a/src/content/docs/curriculum-file-structure.mdx
+++ b/src/content/docs/curriculum-file-structure.mdx
@@ -19,8 +19,6 @@ There are a few terms we use when discussing our curriculum content.
 
 Using those terms, here is how the file structure would be defined:
 
-//-- prettier-ignore -->
-
 ```md
 curriculum/
 ├─ \_meta/


### PR DESCRIPTION
Removed the extra prettier-ignore line which in its current form does nothing.

I ran `astro check` and the `lint` task as well:

```sh
> prettier . --check --cache && eslint . --cache

Checking formatting...
All matched files use Prettier code style!
=============
```

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

![image](https://github.com/user-attachments/assets/05b19450-ef7b-4a8b-aa1e-8565f4b35657)
Left: old version, right: proposed