### PR TITLE
Adding documentation for contributing to quizzes

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -19,6 +19,7 @@ export const collections = {
         'sidebar.best_practices': z.string(),
         'sidebar.work_on_codebase': z.string(),
         'sidebar.work_on_coding_challenges': z.string(),
+        'sidebar.work_on_quizzes': z.string(),
         'sidebar.use_the_curriculum_helpers': z.string(),
         'sidebar.work_on_component_library': z.string(),
         'sidebar.work_on_practice_projects': z.string(),

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -81,6 +81,8 @@ From a learning perspective, it is best to have all of the options of similar le
 
 If the correct answer is always twice as large then the wrong answers, then it becomes too obvious which one to choose.
 
+Also, it is important to note that all answers will be shuffled. So using `all of the above` for an option will not work.
+
 </Aside>
 
 For any question that includes a code block, it is important for that code block to appear below the question like this:

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -1,0 +1,5 @@
+---
+title: How to work on quizzes
+---
+
+import { Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -2,4 +2,158 @@
 title: How to work on quizzes
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+
+We are currently in the process of developing four new certifications which will be more rigorous and time consuming then our previous certifications.
+
+Here are the four new certifications:
+
+- [The Certified Full Stack Developer (fCC-CFSD) Certification](https://www.freecodecamp.org/learn/full-stack-developer/)
+- The Certified Machine Learning Engineer Certification (fCC-CMLE)
+- The Certified Software Systems Engineer Certification (fCC-CSSE)
+- The Certified Data Scientist Certification (fCC-CDS)
+
+You can learn more about these new certification plans in [Quincy's announcement article](https://www.freecodecamp.org/news/freecodecamp-turns-10-major-curriculum-updates/).
+
+Every certification will have a series of quizzes to test camper's knowledge as they move throughout the curriculum.
+
+## Basic structure for quizzes
+
+Each quiz will have a total of 20 questions. Every quiz question will have a set of 4 options (1 correct answer and 3 distractors).
+
+To pass the quiz, a camper will need to get at least 17 questions correct. If they fail the quiz, then there will be a brief cool down period before they are able to take the quiz again.
+
+Before each quiz, there will be a review page listing out all of the topics that were previously discussed in the module.
+
+## Guidelines for designing questions and answers
+
+All quiz questions should come from either the corresponding review page or prior workshop(s).
+If a particular concept has not be taught so far in the curriculum, it cannot be asked on a quiz.
+
+If you believe a corresponding review page is missing a concept that was covered in the module, then please open a separate issue on our [issue tracker](https://github.com/freeCodeCamp/freeCodeCamp/issues).
+
+All quiz questions should be short and easy to understand. If it takes longer then 2 minutes to read and understand the question, then it is to long or unclear.
+
+Here is an example of well designed quiz question:
+
+```md
+Which of the following is the correct syntax for a `div` element?
+```
+
+<Aside type="caution">
+
+Please avoid creating quiz questions that contain multiple questions like this:
+
+```md
+What does the `let` keyword do in JavaScript and what are the differences between `let`, `var` and `const`?
+```
+
+In these situations, it is best to break that question down in smaller separate questions.
+
+</Aside>
+
+Any references to language keywords(ex. HTML element names, CSS properties, JavaScript method names) should be wrapped in `\`` backticks.
+
+```md
+`caption` element
+`outline` property
+`toString()` method
+```
+
+For the list of answers, it is best to keep each option down to two sentences or less.
+
+Here is an example:
+
+```md
+What is an HTML validator used for?
+
+A validator is a tool that makes your HTML code run faster.
+
+A validator is a tool that automatically formats your HTML code.
+
+A validator is a tool that applies styles to your HTML.
+
+A validator is a tool that checks the syntax of HTML code to ensure it is valid.
+```
+
+<Aside type="tip">
+
+From a learning perspective, it is best to have all of the options of similar length.
+
+If the correct answer is always twice as large then the wrong answers, then it becomes too obvious which one to choose.
+
+</Aside>
+
+For any question that includes a code block, it is important for that code block to appear below the question like this:
+
+````md
+What will be the output for the following example?
+
+```js
+if (null) {
+  console.log('Example message');
+}
+```
+````
+
+All multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a new line that only has three backticks and **another empty line**. See example below:
+
+````md
+```{language}
+
+[YOUR CODE HERE]
+
+```
+````
+
+It is best to keep all code examples to a few lines of code like this:
+
+````md
+#### --text--
+
+Which of the following is the correct way to access the third character of a string?
+
+#### --distractors--
+
+```js
+const developer = 'Jessica';
+developer[3];
+```
+
+```js
+const developer = 'Jessica';
+developer[-1];
+```
+
+```js
+const developer = 'Jessica';
+developer[0];
+```
+
+#### --answer--
+
+```js
+const developer = 'Jessica';
+developer[2];
+```
+````
+
+## Acceptable resources to use for creating questions
+
+If you need help creating questions, then you can look through a few of the existing quizzes in the certification.
+
+You can also look to our [Developer Quiz Site](https://developerquiz.org/) which has over 1600 quiz questions. Just make sure that question was in fact covered in the module before adding it.
+
+If you need help with formatting your questions, please reach out on the [discord](https://discord.com/invite/freecodecamp-692816967895220344) or [forum](https://forum.freecodecamp.org/) contributor channels.
+
+<Aside type="danger">
+
+Any use of AI tools to help you create questions is prohibited.
+
+We have found these tools to be unreliable and not always producing the highest quality of results.
+
+Also, any question that was taken from external quiz sites is prohibited.
+
+Please come up with your own quiz questions and answers.
+
+</Aside>

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to work on quizzes
+title: How to Work on Quizzes
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -17,7 +17,7 @@ You can learn more about these new certification plans in [Quincy's announcement
 
 Every certification will have a series of quizzes to test camper's knowledge as they move throughout the curriculum.
 
-## Basic structure for quizzes
+## Basic Structure for Quizzes
 
 Each quiz will have a total of 20 questions. Every quiz question will have a set of 4 options (1 correct answer and 3 distractors).
 
@@ -25,10 +25,9 @@ To pass the quiz, a camper will need to get at least 17 questions correct. If th
 
 Before each quiz, there will be a review page listing out all of the topics that were previously discussed in the module.
 
-## Guidelines for designing questions and answers
+## Guidelines for Designing Questions and Answers
 
-All quiz questions should come from either the corresponding review page or prior workshop(s).
-If a particular concept has not be taught so far in the curriculum, it cannot be asked on a quiz.
+All quiz questions should come from either the corresponding review page or prior workshop(s). If a particular concept has not been taught so far in the curriculum, it cannot be asked on a quiz.
 
 If you believe a corresponding review page is missing a concept that was covered in the module, then please open a separate issue on our [issue tracker](https://github.com/freeCodeCamp/freeCodeCamp/issues).
 
@@ -138,13 +137,13 @@ developer[2];
 ```
 ````
 
-## Acceptable resources to use for creating questions
+## Acceptable Resources to Use for Creating Questions
 
 If you need help creating questions, then you can look through a few of the existing quizzes in the certification.
 
 You can also look to our [Developer Quiz Site](https://developerquiz.org/) which has over 1600 quiz questions. Just make sure that question was in fact covered in the module before adding it.
 
-If you need help with formatting your questions, please reach out on the [discord](https://discord.com/invite/freecodecamp-692816967895220344) or [forum](https://forum.freecodecamp.org/) contributor channels.
+If you need help with formatting your questions, please reach out on the [Discord](https://discord.com/invite/freecodecamp-692816967895220344) or [forum](https://forum.freecodecamp.org/) contributor channels.
 
 <Aside type="danger">
 

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -49,6 +49,7 @@
   "sidebar.best_practices": "Follow best-practices",
   "sidebar.work_on_codebase": "Work on Codebase",
   "sidebar.work_on_coding_challenges": "Work on Coding Challenges",
+  "sidebar.work_on_quizzes": "Work on Quizzes",
   "sidebar.use_the_curriculum_helpers": "Use the Curriculum Helpers",
   "sidebar.work_on_component_library": "Work on Component Library",
   "sidebar.work_on_practice_projects": "Work on Practice Projects",

--- a/src/update-pagination.ts
+++ b/src/update-pagination.ts
@@ -55,6 +55,10 @@ export const content: Section[] = [
         title: 'sidebar.work_on_coding_challenges'
       },
       {
+        href: '/how-to-work-on-quizzes/',
+        title: 'sidebar.work_on_quizzes'
+      },
+      {
         href: '/curriculum-help/',
         title: 'sidebar.use_the_curriculum_helpers'
       },


### PR DESCRIPTION
After the initial QA for the existing quizzes, we do want contributors to be able to contribute to quizzes. But they need proper guidelines so they can be successful. 

So here is what I came up with so far as a starting point. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
