### PR TITLE
fix: use absolute URLs in reply templates

### DIFF
--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -37,7 +37,7 @@ Once you resolve these issues, we will be able to review your PR and merge it. �
 
 ---
 
-Feel free to reference the [contributing guidelines](/how-to-work-on-coding-challenges/#testing-challenges) for instructions on running the CI build locally. ✅
+Feel free to reference the [contributing guidelines](https://contribute.freecodecamp.org/how-to-work-on-coding-challenges/#testing-challenges) for instructions on running the CI build locally. ✅
 ```
 
 ## Syncing Fork
@@ -149,7 +149,7 @@ If you're unfamiliar with certain aspects, our [contributing guidelines](https:/
 <Steps>
 
 1. **Editing on GitHub:** While it's possible to edit files directly on GitHub, it's typically better not to. This helps avoid inadvertent mistakes like typos that can disrupt tests.
-2. **Pull Request Title:** Please ensure the PR title follows [our convention](/how-to-open-a-pull-request/#prepare-a-good-pr-title).
+2. **Pull Request Title:** Please ensure the PR title follows [our convention](https://contribute.freecodecamp.org/how-to-open-a-pull-request/#prepare-a-good-pr-title).
 3. **Linking Issues:** Please ensure you link issues using the designated method. Simply update the `XXXXXX` in the PR description to include the issue number. This keeps our records organized and clear.
 4. **Engaging with the Team:** We know you're eager, but kindly keep mentions and review requests limited. Our maintainers are always on the lookout and will attend to PRs in the order they come in.
 5. **Branch Management:** It's a good practice not to work directly off your `main` branch. Creating separate branches for different changes allows you to smoothly update your PR even as the main repository progresses.


### PR DESCRIPTION
As per the open issue, I updated the two URL's with two urls with  'https://contribute.freecodecamp.org' at the beginning

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [Y ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #603 

<!-- Feel free to add any additional description of changes below this line -->
As per the Issue, there were 2 invalud URL's in the reply-templates.mdx file which I fixed.
