### PR TITLE
feat: add note about resetting submodule when it shows in status

### DIFF
--- a/src/content/docs/how-to-contribute-to-the-codebase.mdx
+++ b/src/content/docs/how-to-contribute-to-the-codebase.mdx
@@ -52,8 +52,6 @@ Follow these steps:
    git submodule update --init
    ```
 
-no changes added to commit (use "git add" and/or "git commit -a")
-
 2. Sync the latest changes from the freeCodeCamp upstream `main` branch to your `main` fork branch:
 
    :::caution

--- a/src/content/docs/how-to-contribute-to-the-codebase.mdx
+++ b/src/content/docs/how-to-contribute-to-the-codebase.mdx
@@ -36,6 +36,24 @@ Follow these steps:
    git checkout main
    ```
 
+   If you get a message similar to this one:
+
+   ```bash
+   On branch feat/colour-picker
+   Changes not staged for commit:
+     (use "git add <file>..." to update what will be committed)
+     (use "git restore <file>..." to discard changes in working directory)
+        modified:   curriculum/i18n-curriculum (new commits)
+   ```
+
+   Then the i18n curriculum submodule is out of sync. You should NOT commit changes to the submodule through our main repository. Instead, to resolve this, run:
+
+   ```bash
+   git submodule update --init
+   ```
+
+no changes added to commit (use "git add" and/or "git commit -a")
+
 2. Sync the latest changes from the freeCodeCamp upstream `main` branch to your `main` fork branch:
 
    :::caution


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This bloody submodule is always out of sync and I can never remember how to fix it. And if I'm having that problem, there's a very good chance our contributors are too.