### PR TITLE
chore: add firebase CLI setup step to mobile guide

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -41,10 +41,11 @@ Once you have the prerequisites installed, you need to prepare your development 
 <Steps>
 
 1. Install [Git](https://git-scm.com/) or your favorite Git client, if you haven't already. Update to the latest version; the version that came bundled with your OS may be outdated.
-2. Set up [Android Studio](https://developer.android.com/studio) and [Android Emulators](https://developer.android.com/studio/run/managing-avds) with the latest released Android version. We recommend using the Pixel 3a XL and Nexus One(for emulating smaller screens).
+2. Set up [Android Studio](https://developer.android.com/studio) and [Android Emulators](https://developer.android.com/studio/run/managing-avds) with the latest released Android version. We recommend using the Pixel 3a XL and Nexus One (for emulating smaller screens).
 3. (Optional for MacOS) Set up Xcode and iOS Simulator with the latest released iOS version.
-4. (Optional but recommended) [Set up an SSH Key](https://help.github.com/articles/generating-an-ssh-key/) for GitHub.
-5. Install a code editor of your choice.
+4. Install the [Firebase CLI](https://firebase.google.com/docs/cli#setup_update_cli) and [FlutterFire CLI](https://firebase.google.com/docs/flutter/setup#install-cli-tools).
+5. (Optional but recommended) [Set up an SSH Key](https://help.github.com/articles/generating-an-ssh-key/) for GitHub.
+6. Install a code editor of your choice.
 
    We highly recommend using [Visual Studio Code](https://code.visualstudio.com/) or Android Studio. We also recommend installing the official [extensions](https://docs.flutter.dev/get-started/editor?tab=vscode).
 
@@ -184,7 +185,7 @@ flutter pub get
 
 #### Step 3: Start the freeCodeCamp mobile app
 
-Start the emulator of your choice(Android or iOS) and wait for the bootup process to complete.
+Start the emulator of your choice (Android or iOS) and wait for the bootup process to complete.
 
 You can now start the app by running the following command:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The mobile setup guide is missing a step on installing Firebase CLI.

<!-- Feel free to add any additional description of changes below this line -->
