### PR TITLE
fix: use correct capitalization for whitespace

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -394,7 +394,7 @@ Using `__helpers.removeCssComments()`, `__helpers.removeHtmlComments()`, or `__h
 
 ### Removing Whitespace
 
-Using `__helpers.removeWhitespace()` allows you to pass the camper's code (through the `code` variable) to remove all whitespace.
+Using `__helpers.removeWhiteSpace()` allows you to pass the camper's code (through the `code` variable) to remove all whitespace.
 
 ## permutateRegex
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

There was an issue with the documentation regarding `removeWhiteSpace`.  The name of the method did not match the function present in the library. 

https://github.com/freeCodeCamp/curriculum-helpers/blob/d66d00e6bb68da93bdf04b47b95d1b48706c981c/lib/index.ts#L184
