### PR TITLE
docs: fix typos in Authors Analytics Manual (Google Analytics spelling, capitalization)

### DIFF
--- a/src/content/docs/authors-analytics-manual.mdx
+++ b/src/content/docs/authors-analytics-manual.mdx
@@ -12,12 +12,12 @@ If you are an author with access to the publication's Google Analytics Property 
 
 To search for engagement reports in a specific language:
 
-![Image - Show steps to search by language on googla analytics](https://contribute.freecodecamp.org/images/google-analytics/search-by-language.png)
+![Image - Show steps to search by language on Google Analytics](https://contribute.freecodecamp.org/images/google-analytics/search-by-language.png)
 
 <Steps>
 
 1. From the top dropdown menu, select `News`.
-2. From the sidebar, click on
+2. From the sidebar, click
    `Reports`.
 3. From the secondary sidebar, select `Engagement`.
 4. Click on
@@ -25,7 +25,7 @@ To search for engagement reports in a specific language:
 5. In the search bar, type the subpath for the desired
    language.
 6. From the dropdown under the search bar, choose `Page path and
-screen class`.
+Screen class`.
 
 </Steps>
 


### PR DESCRIPTION
This pull request fixes a few minor typos and formatting issues in the Authors Analytics Manual documentation page:

Corrected the spelling of "googla analytics" to "Google Analytics" in image alt texts.
Capitalized "Screen class" in accordance with the actual label in Google Analytics.
Improved sentence flow in one step for clarity (optional).
These updates improve the accuracy and readability of the guide.