### PR TITLE
fix: update or removed outdated todos in codebasebest practices page

### DIFF
--- a/src/content/docs/codebase-best-practices.mdx
+++ b/src/content/docs/codebase-best-practices.mdx
@@ -89,8 +89,6 @@ const myObject: MyObject = {};
 
 //-- #### Redux Actions -->
 
-//-- TODO: Once refactored to TS, showcase naming convention for Reducers/Actions and how to type dispatch funcs -->
-
 ## Redux
 
 ### Action Definitions


### PR DESCRIPTION
This PR updates or removes outdated TODOs mentioned in the Codebase Best Practices page.

fixes #393  