### PR TITLE
Fixed a typo in troubleshooting-development-issues.mdx

### DIFF
--- a/src/content/docs/troubleshooting-development-issues.mdx
+++ b/src/content/docs/troubleshooting-development-issues.mdx
@@ -127,7 +127,7 @@ If you get errors while installing the dependencies, please make sure that you a
 
 <Aside type='caution' title='Slow downloads'>
 
-The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using Gitpod instead of an offline setup. We recommed 30-50 mbps connections for the best experience.
+The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using Gitpod instead of an offline setup. We recommend 30-50 mbps connections for the best experience.
 
 </Aside>
 


### PR DESCRIPTION
Hi, I fixed a small typo in [troubleshooting-development-issues.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/troubleshooting-development-issues.mdx).

**Before**

```text
We `recommed` 30-50 mbps connections for the best experience.
```

**After**

```text
We `recommend` 30-50 mbps connections for the best experience.
```