### PR TITLE
Fixed filename mispelling in language-lead-handbook.mdx

### DIFF
--- a/src/content/docs/language-lead-handbook.mdx
+++ b/src/content/docs/language-lead-handbook.mdx
@@ -53,7 +53,7 @@ With `link` being the link of the original article.
 2. Run `pnpm install`
 3. Add the prompt in [src/tasks/task_auto_translate_step_02_trans_articles.ts](https://github.com/freeCodeCamp/articles-auto-translate-action/blob/main/src/tasks/task_auto_translate_step_02_trans_articles.ts) file as shown in the image below
 4. Run `pnpm run build`. This will update `dist/index.js`
-5. Open a pull request including the modified files (`src/tasks/task_auto_translate_step_02_trans_articels.ts` and `dist/index.js`)
+5. Open a pull request including the modified files (`src/tasks/task_auto_translate_step_02_trans_articles.ts` and `dist/index.js`)
 
 The prompt should say something similar to below. You can customize the prompt to get the best result for your language.
 


### PR DESCRIPTION
Hi, I fixed a small typo in [language-lead-handbook.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/language-lead-handbook.mdx).

**Before**

```js
(`src/tasks/task_auto_translate_step_02_trans_articels.ts` and `dist/index.js`) // articels
```

**After**

```js
(`src/tasks/task_auto_translate_step_02_trans_articles.ts` and `dist/index.js`) // articles
```