### PR TITLE
Fixed a small typo in how-to-setup-freecodecamp-locally.mdx

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -423,7 +423,7 @@ If you have issues with the setup, check out the [troubleshooting section](/trou
 | `pnpm run seed`                | Creates authorized test users and inserts them into MongoDB. Also runs `seed:exams` and `seed:surveys` below. |
 | `pnpm run seed:certified-user` | Creates authorized test users with certifications fully completed, and inserts them into MongoDB.             |
 | `pnpm run seed:exams`          | Creates exams and inserts them into MongoDB.                                                                  |
-| `pnpm run seed:surveys`        | Creates surveys for defaults users and inserts them into MongoDB.                                             |
+| `pnpm run seed:surveys`        | Creates surveys for default users and inserts them into MongoDB.                                             |
 | `pnpm run develop`             | Starts the freeCodeCamp API Server and Client Applications.                                                   |
 | `pnpm run clean`               | Uninstalls all dependencies and cleans up caches.                                                             |
 


### PR DESCRIPTION
Hi, I fixed few typos in [how-to-setup-freecodecamp-locally.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/how-to-setup-freecodecamp-locally.mdx).

-   `defaults users` → `default users`