### PR TITLE
Fixed a small typo how-to-work-on-coding-challenges.mdx

### DIFF
--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -476,7 +476,7 @@ Challenge tests can make use of the Node.js and Chai.js assertion libraries. Als
 The `__helpers` object is only available in the `# --hints--` test sections. It is not available in `# --before-all--` or `# --before-each--` sections.
 :::
 
-### Guidlines for assertions
+### Guidelines for assertions
 
 If a method exists in Chai.js that expresses what is being tested for, its use is preferred.
 


### PR DESCRIPTION
Hi, I fixed few typos in [how-to-work-on-coding-challenges.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/how-to-work-on-coding-challenges.mdx).

-   `Guidlines` → `Guidelines`