### PR TITLE
Fixed few typos in how-to-work-on-quizzes.mdx

### DIFF
--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-We are currently in the process of developing a new format for certifications which will be more rigorous and time consuming then our previous certifications.
+We are currently in the process of developing a new format for certifications which will be more rigorous and time consuming than our previous certifications.
 
 Every module of the certification will have a quiz to test camper's knowledge as they move throughout the curriculum.
 
@@ -38,7 +38,7 @@ All quiz questions should come from either the corresponding review page or prio
 
 If you believe a corresponding review page is missing a concept that was covered in the module, then please open a separate issue on our [issue tracker](https://github.com/freeCodeCamp/freeCodeCamp/issues).
 
-All quiz questions should be short and easy to understand. If it takes longer then 2 minutes to read and understand the question, then it is to long or unclear.
+All quiz questions should be short and easy to understand. If it takes longer than 2 minutes to read and understand the question, then it is too long or unclear.
 
 Here is an example of well designed quiz question:
 
@@ -86,7 +86,7 @@ A validator is a tool that checks the syntax of HTML code to ensure it is valid.
 
 From a learning perspective, it is best to have all of the options of similar length.
 
-If the correct answer is always twice as large then the wrong answers, then it becomes too obvious which one to choose.
+If the correct answer is always twice as large than the wrong answers, then it becomes too obvious which one to choose.
 
 Also, it is important to note that all answers will be shuffled. So using `all of the above` for an option will not work.
 


### PR DESCRIPTION
Hi, I fixed a few typos in [how-to-work-on-quizzes.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/how-to-work-on-quizzes.mdx). 

-   `then` → `than`
-   `to` → `too`