### PR TITLE
Corrected 'ie.' to 'i.e.' in how-to-setup-freecodecamp-mobile-app-locally.mdx

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -149,7 +149,7 @@ If you do run into issues, first perform a web search for your issue and see if 
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [our chat server](https://discord.gg/PRyKn3Vbay).
 
 :::note
-The `mobile` directory contains two folders ie. `mobile-api` and `mobile-app`. `mobile-api` contains the API code used for serving the podcasts. `mobile-app` contains the Flutter app which is where you should be when you follow the below steps.
+The `mobile` directory contains two folders i.e. `mobile-api` and `mobile-app`. `mobile-api` contains the API code used for serving the podcasts. `mobile-app` contains the Flutter app which is where you should be when you follow the below steps.
 :::
 
 ### Configuring Dependencies


### PR DESCRIPTION
Hi, I changed `ie.` to `i.e.` in [how-to-setup-freecodecamp-mobile-app-locally.mdx](https://github.com/freeCodeCamp/contribute/blob/main/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx). 