### PR TITLE
refactor: change Gitpod references to GitHub Codespaces

### DIFF
--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -280,11 +280,11 @@ npx playwright show-report
 
 **For more insights on issues visit the official documentation.**
 
-## Playwright-Ona Setup
+## Playwright-GitHub Codespaces Setup
 
 ### Ensure Development Environment is Running
 
-If starting the Ona environment did not automatically develop the environment:
+If starting the GitHub Codespaces environment did not automatically develop the environment:
 
 - Follow the [MongoDB installation guide](https://www.mongodb.com/basics/get-started).
 
@@ -320,7 +320,7 @@ To install necessary dependencies for running Playwright run the following comma
 pnpm run playwright:install-build-tools
 ```
 
-### Run the Playwright Tests on Ona
+### Run the Playwright Tests on GitHub Codespaces
 
 To run all Playwright tests, run the following command:
 

--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -284,7 +284,6 @@ npx playwright show-report
 
 ### Ensure Development Environment is Running
 
-
 - Follow the [MongoDB installation guide](https://www.mongodb.com/basics/get-started).
 
 - Create the .env

--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -280,11 +280,11 @@ npx playwright show-report
 
 **For more insights on issues visit the official documentation.**
 
-## Playwright-Gitpod Setup
+## Playwright-Ona Setup
 
 ### Ensure Development Environment is Running
 
-If starting the Gitpod environment did not automatically develop the environment:
+If starting the Ona environment did not automatically develop the environment:
 
 - Follow the [MongoDB installation guide](https://www.mongodb.com/basics/get-started).
 
@@ -320,7 +320,7 @@ To install necessary dependencies for running Playwright run the following comma
 pnpm run playwright:install-build-tools
 ```
 
-### Run the Playwright Tests on Gitpod
+### Run the Playwright Tests on Ona
 
 To run all Playwright tests, run the following command:
 

--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -284,7 +284,6 @@ npx playwright show-report
 
 ### Ensure Development Environment is Running
 
-If starting the GitHub Codespaces environment did not automatically develop the environment:
 
 - Follow the [MongoDB installation guide](https://www.mongodb.com/basics/get-started).
 

--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -280,7 +280,7 @@ npx playwright show-report
 
 **For more insights on issues visit the official documentation.**
 
-## Playwright-GitHub Codespaces Setup
+## Set up for Playwright on GitHub Codespaces
 
 ### Ensure Development Environment is Running
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -29,9 +29,9 @@ You can find all of freeCodeCamp.org's curricular content in the [`/curriculum/c
 Before you work on the curriculum, you would need to set up some tooling to help you test your changes. You can use any option from the below:
 
 - You can [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally/). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
-- Use Gitpod, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
+- Use Ona, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
 
-  [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
+  [![Open in Ona](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
 
 ### How to work on practice projects
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -31,7 +31,7 @@ Before you work on the curriculum, you would need to set up some tooling to help
 - You can [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally/). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
 - Use GitHub Codespaces, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
 
-  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/github/docs)
+  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/freeCodeCamp/freeCodeCamp)
 
 ### How to work on practice projects
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -29,9 +29,9 @@ You can find all of freeCodeCamp.org's curricular content in the [`/curriculum/c
 Before you work on the curriculum, you would need to set up some tooling to help you test your changes. You can use any option from the below:
 
 - You can [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally/). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
-- Use Ona, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
+- Use GitHub Codespaces, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
 
-  [![Open in Ona](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
+  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/setting-up-your-repository/facilitating-quick-creation-and-resumption-of-codespaces)
 
 ### How to work on practice projects
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -31,7 +31,7 @@ Before you work on the curriculum, you would need to set up some tooling to help
 - You can [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally/). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
 - Use GitHub Codespaces, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
 
-  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/setting-up-your-repository/facilitating-quick-creation-and-resumption-of-codespaces)
+  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/github/docs)
 
 ### How to work on practice projects
 

--- a/src/content/docs/moderator-handbook.mdx
+++ b/src/content/docs/moderator-handbook.mdx
@@ -85,7 +85,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    These are changes to the code in a challenge - the challenge seed, challenge solution, and test strings.
 
-   These pull requests need to be pulled down from GitHub and tested on your local computer or Gitpod to make sure the challenge tests can still be passed with the current solution and to make sure the new code doesn't introduce any errors.
+   These pull requests need to be pulled down from GitHub and tested on your local computer or Ona to make sure the challenge tests can still be passed with the current solution and to make sure the new code doesn't introduce any errors.
 
    Some contributors may try to add additional tests to cover pedantic corner-cases. We need to be careful to not make the challenge too complicated. These challenges and their tests should be as simple and intuitive as possible. Aside from the algorithm challenges and interview prep section, learners should be able to solve each challenge within about 2 minutes.
 

--- a/src/content/docs/moderator-handbook.mdx
+++ b/src/content/docs/moderator-handbook.mdx
@@ -85,7 +85,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    These are changes to the code in a challenge - the challenge seed, challenge solution, and test strings.
 
-   These pull requests need to be pulled down from GitHub and tested on your local computer or Ona to make sure the challenge tests can still be passed with the current solution and to make sure the new code doesn't introduce any errors.
+   These pull requests need to be pulled down from GitHub and tested on your local computer or GitHub Codespaces to make sure the challenge tests can still be passed with the current solution and to make sure the new code doesn't introduce any errors.
 
    Some contributors may try to add additional tests to cover pedantic corner-cases. We need to be careful to not make the challenge too complicated. These challenges and their tests should be as simple and intuitive as possible. Aside from the algorithm challenges and interview prep section, learners should be able to solve each challenge within about 2 minutes.
 

--- a/src/content/docs/troubleshooting-development-issues.mdx
+++ b/src/content/docs/troubleshooting-development-issues.mdx
@@ -28,7 +28,7 @@ Therefore we recommend to clone this repo into a folder which is mainly used by 
 
 See [this GitHub Issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/40632) for further information about this problem.
 
-## Troubleshooting port issues on Ona
+## Troubleshooting port issues on GitHub Codespaces
 
 Sometimes the service on port `8000` doesn't go live. This is common when you are restarting an inactive workspace.
 
@@ -46,7 +46,7 @@ If the service is not coming up on port `8000`, you can troubleshoot using these
   pnpm run develop -- -H '0.0.0.0'
   ```
 
-This should make port `8000` available. Be mindful of [how the URLs & Ports work within a Ona](https://ona.com/docs/classic/user/configure/workspaces/ports) workspace.
+This should make port `8000` available. Be mindful of [how the URLs & Ports work within a GitHub Codespace](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace).
 
 ## Issues with Missing UI, Fonts, Language Strings, or Build Errors
 
@@ -127,7 +127,7 @@ If you get errors while installing the dependencies, please make sure that you a
 
 <Aside type='caution' title='Slow downloads'>
 
-The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using Ona instead of an offline setup. We recommend 30-50 mbps connections for the best experience.
+The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using GitHub Codespaces instead of an offline setup. We recommend 30-50 mbps connections for the best experience.
 
 </Aside>
 

--- a/src/content/docs/troubleshooting-development-issues.mdx
+++ b/src/content/docs/troubleshooting-development-issues.mdx
@@ -28,7 +28,7 @@ Therefore we recommend to clone this repo into a folder which is mainly used by 
 
 See [this GitHub Issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/40632) for further information about this problem.
 
-## Troubleshooting port issues on Gitpod
+## Troubleshooting port issues on Ona
 
 Sometimes the service on port `8000` doesn't go live. This is common when you are restarting an inactive workspace.
 
@@ -46,7 +46,7 @@ If the service is not coming up on port `8000`, you can troubleshoot using these
   pnpm run develop -- -H '0.0.0.0'
   ```
 
-This should make port `8000` available. Be mindful of [how the URLs & Ports work within a Gitpod](https://www.gitpod.io/docs/configure/workspaces/ports) workspace.
+This should make port `8000` available. Be mindful of [how the URLs & Ports work within a Ona](https://ona.com/docs/classic/user/configure/workspaces/ports) workspace.
 
 ## Issues with Missing UI, Fonts, Language Strings, or Build Errors
 
@@ -127,7 +127,7 @@ If you get errors while installing the dependencies, please make sure that you a
 
 <Aside type='caution' title='Slow downloads'>
 
-The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using Gitpod instead of an offline setup. We recommend 30-50 mbps connections for the best experience.
+The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using Ona instead of an offline setup. We recommend 30-50 mbps connections for the best experience.
 
 </Aside>
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #926 

<!-- Feel free to add any additional description of changes below this line -->

There have been four (4) files which had references to Gitpod and thus were affected by the changes I made, they are:
 - src/content/docs/how-to-add-playwright-tests.mdx
 - src/content/docs/how-to-work-on-coding-challenges.mdx
 - src/content/docs/moderator-handbook.mdx
 - src/content/docs/troubleshooting-development-issues.mdx

While making the update of the brand in the "src/content/docs/troubleshooting-development-issues.mdx" file, I took the initiative to also update the link to their actual documentation (even though their automatic redirection was functional).

There is one untouched link, though, inside "src/content/docs/how-to-work-on-coding-challenges.mdx" as it is part of freeCodeCamp.org workspace.
Again, redirection is functional, but I believe it would help for consistency.

After another check inside the "src/content/docs/" folder, I made a preview to verify if there won't be any more results about Gitpod while using the "Search bar", since this only work in preview.
