### PR TITLE
fix(docs): correct API route from /explorer to /documentation in setu…

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -404,7 +404,7 @@ You now have a copy of freeCodeCamp's entire learning platform running on your l
 
 - The API server serves endpoints at `http://localhost:3000`.
 - The Gatsby app serves the client application at `http://localhost:8000`.
-- All the APIs are available at `http://localhost:3000/explorer`.
+- All the APIs are available at `http://localhost:3000/documentation`.
 
 <Aside type='note'>
 


### PR DESCRIPTION
### Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

### Description

Fixed incorrect localhost route in Step 4 of the "Setup a dev environment for freeCodeCamp" guide.

Changed `/explorer` → `/documentation` in  
`contribute/src/content/docs/how-to-setup-freecodecamp-locally.mdx`.

Closes #948

<!-- Feel free to add any additional description of changes below this line -->
