### PR TITLE
docs: update link to YouTube guide

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -31,7 +31,7 @@ Yes! You can contribute articles or videos.
 
 To write articles for freeCodeCamp News, visit our [publication guide](https://www.freecodecamp.org/news/how-to-write-for-freecodecamp/) and check out our [style guide](https://www.freecodecamp.org/news/developer-news-style-guide/) to help you write better content.
 
-For contributing educational videos to our YouTube channel, follow the [YouTube channel guide](https://www.freecodecamp.org/news/how-to-contribute-to-the-freecodecamp-community-youtube-channel-b86bce4c865/).
+For contributing educational videos to our YouTube channel, follow the [YouTube channel guide](https://www.freecodecamp.org/news/how-to-create-a-great-technical-course).
 
 ### How can I report a new bug?
 


### PR DESCRIPTION
Updating only the link. While it would make sense to have the guide in the contribute repo, this guide and the publication guides have historically been shared a lot over the internet and it make practical sense to link to them from this project.

Closes https://github.com/freeCodeCamp/contribute/issues/55