### PR TITLE
fix: expand explanation of the `.getPropVal()` method

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -198,7 +198,13 @@ assert.strictEqual(helper.getStyle('body')?.width, '100%');
 The helper attaches a `.getPropVal()` method to the style declaration object that allows you to get the value of a specific property:
 
 ```js
-assert.strictEqual(helper.getStyle('body').getPropVal('width'), '100%');
+assert.strictEqual(helper.getStyle('body').getPropVal('background-color'), 'rgb(118, 201, 255)');
+```
+
+The `.getPropVal()` method accepts an optional second parameter that controls whitespace handling. When you pass `true` as the second argument, it automatically strips all whitespace from the returned value:
+
+```js
+assert.strictEqual(helper.getStyle('body').getPropVal('background-color', true), 'rgb(118,201,255)');
 ```
 
 On the style object returned, there is a native method called `getPropertyValue` that can retrieve
@@ -263,12 +269,17 @@ This method allows you to test that specific properties have been set:
 assert.strictEqual(helper.getStyleAny(['.earth', '.sky'])?.width, '100%');
 ```
 
-The helper attaches a `.getPropVal()` method to the style declaration object that allows you to get the value of a specific property:
+Like the style objects returned by `.getStyle()`, the object returned by `.getStyleAny()` also includes the enhanced `.getPropVal()` method (documented in the `.getStyle()` section). This provides the same convenient property access and whitespace handling:
 
 ```js
 assert.strictEqual(
-  helper.getStyleAny(['.earth', '.sky']).getPropVal('width'),
-  '100%'
+  helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color'),
+  'rgb(255, 207, 51)'
+);
+
+assert.strictEqual(
+  helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color'),
+  'rgb(255,207,51)'
 );
 ```
 

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -275,7 +275,7 @@ This method allows you to test that specific properties have been set:
 assert.strictEqual(helper.getStyleAny(['.earth', '.sky'])?.width, '100%');
 ```
 
-Like the style objects returned by `.getStyle()`, the object returned by `.getStyleAny()` also includes the enhanced `.getPropVal()` method (documented in the `.getStyle()` section). This provides the same convenient property access and whitespace handling:
+Like the style objects returned by `.getStyle()`, the object returned by `.getStyleAny()` also includes the `.getPropVal()` method (as desired in the `.getStyle()` section). Here `.getPropVal()` provides the same property access and whitespace handling:
 
 ```js
 assert.strictEqual(
@@ -284,7 +284,7 @@ assert.strictEqual(
 );
 
 assert.strictEqual(
-  helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color'),
+  helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color', true),
   'rgb(255,207,51)'
 );
 ```

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -199,7 +199,7 @@ There are three ways to retrieve CSS values from the returned object:
 
 `.getPropertyValue()` is a native CSS style declaration object method for reading CSS properties by their kebab-case name (for example, 'background-color'). See [MDN: CSSStyleDeclaration.getPropertyValue()](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue).
 
-The `.getStyle()` helper attaches the `.getPropVal()` method to the style declaration object. It is a wrapper around the native `getPropertyValue()` method with an optional whitespace-stripping feature. It accepts an optional second parameter that, when `true`, strips all whitespace from the returned value.
+The `.getStyle()` helper attaches the `.getPropVal()` method to the style declaration object. It wraps the native `getPropertyValue()` method and optionally strips whitespace. It accepts an optional second parameter that, when `true`, removes all whitespace from the returned value.
 
 `getPropVal()` default behavior (preserves whitespace):
 

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -189,13 +189,19 @@ If you call the `getStyle` method with `body` as an argument, you would get an o
 }
 ```
 
-This method allows you to test that specific properties have been set:
+There are three ways to retrieve CSS values from the returned object:
 
-```js
-assert.strictEqual(helper.getStyle('body')?.width, '100%');
-```
+| Method                       | Example                                       | Returns  |
+| ---------------------------- | --------------------------------------------- | -------- |
+| Direct property access       | `getStyle('body')?.width`                     | `'100%'` |
+| Native `.getPropertyValue()` | `getStyle('body')?.getPropertyValue('width')` | `'100%'` |
+| Helper `.getPropVal()`       | `getStyle('body')?.getPropVal('width')`       | `'100%'` |
 
-The helper attaches a `.getPropVal()` method to the style declaration object that allows you to get the value of a specific property:
+`.getPropertyValue()` is a native CSS style declaration object method for reading CSS properties by their kebab-case name (for example, 'background-color'). See [MDN: CSSStyleDeclaration.getPropertyValue()](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue).
+
+The `.getStyle()` helper attaches the `.getPropVal()` method to the style declaration object. It is a wrapper around the native `getPropertyValue()` method with an optional whitespace-stripping feature. It accepts an optional second parameter that, when `true`, strips all whitespace from the returned value.
+
+`getPropVal()` default behavior (preserves whitespace):
 
 ```js
 assert.strictEqual(
@@ -204,7 +210,7 @@ assert.strictEqual(
 );
 ```
 
-The `.getPropVal()` method accepts an optional second parameter that controls whitespace handling. When you pass `true` as the second argument, it automatically strips all whitespace from the returned value:
+`getPropVal()` with whitespace stripping (true removes all whitespace):
 
 ```js
 assert.strictEqual(
@@ -213,13 +219,9 @@ assert.strictEqual(
 );
 ```
 
-On the style object returned, there is a native method called `getPropertyValue` that can retrieve
-CSS properties. More info at [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue).
-
 #### `.getStyleAny()`
 
-The `.getStyleAny()` method takes multiple CSS possible selectors and returns
-the first matching CSS style declaration object.
+The `.getStyleAny()` method takes multiple CSS possible selectors and returns the first matching CSS style declaration object.
 
 For example, if the camper has written the following CSS:
 
@@ -269,20 +271,28 @@ If you call the `getStyleAny()` method with `.earth` and `.sky` as arguments, yo
 }
 ```
 
-This method allows you to test that specific properties have been set:
+There are three ways to retrieve CSS values from the returned object:
 
-```js
-assert.strictEqual(helper.getStyleAny(['.earth', '.sky'])?.width, '100%');
-```
+| Method                       | Example                                                      | Returns  |
+| ---------------------------- | ------------------------------------------------------------ | -------- |
+| Direct property access       | `getStyleAny(['.earth', '.sky'])?.width`                     | `'100%'` |
+| Native `.getPropertyValue()` | `getStyleAny(['.earth', '.sky'])?.getPropertyValue('width')` | `'100%'` |
+| Helper `.getPropVal()`       | `getStyleAny(['.earth', '.sky'])?.getPropVal('width')`       | `'100%'` |
 
-Like the style objects returned by `.getStyle()`, the object returned by `.getStyleAny()` also includes the `.getPropVal()` method (as desired in the `.getStyle()` section). Here `.getPropVal()` provides the same property access and whitespace handling:
+Like the CSS style declaration objects returned by `.getStyle()`, the object returned by `.getStyleAny()` also includes the `.getPropVal()` method (see the `.getStyle()` section). It provides the same property access and whitespace stripping feature.
+
+`getPropVal()` default behavior (preserves whitespace):
 
 ```js
 assert.strictEqual(
   helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color'),
   'rgb(255, 207, 51)'
 );
+```
 
+`getPropVal()` with whitespace stripping (true removes all whitespace):
+
+```js
 assert.strictEqual(
   helper.getStyleAny(['.earth', '.sky']).getPropVal('background-color', true),
   'rgb(255,207,51)'

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -198,13 +198,19 @@ assert.strictEqual(helper.getStyle('body')?.width, '100%');
 The helper attaches a `.getPropVal()` method to the style declaration object that allows you to get the value of a specific property:
 
 ```js
-assert.strictEqual(helper.getStyle('body').getPropVal('background-color'), 'rgb(118, 201, 255)');
+assert.strictEqual(
+  helper.getStyle('body').getPropVal('background-color'),
+  'rgb(118, 201, 255)'
+);
 ```
 
 The `.getPropVal()` method accepts an optional second parameter that controls whitespace handling. When you pass `true` as the second argument, it automatically strips all whitespace from the returned value:
 
 ```js
-assert.strictEqual(helper.getStyle('body').getPropVal('background-color', true), 'rgb(118,201,255)');
+assert.strictEqual(
+  helper.getStyle('body').getPropVal('background-color', true),
+  'rgb(118,201,255)'
+);
 ```
 
 On the style object returned, there is a native method called `getPropertyValue` that can retrieve


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The sections on the `.getStyle()` and `.getStyleAny()` helpers mentioned the `.getPropVal()` method but didn’t mention the optional second parameter for whitespace handling. I’ve added this missing explanation and updated the code examples.
