### PR TITLE
docs: remove Codespaces recommended badge

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -73,16 +73,16 @@ Next, you need to choose between setting up a cloud IDE or your own machine.
 
 If you're looking to make a one-time contribution or want the fastest setup, use GitHub Codespaces which provides a ready-to-code environment in your web browser using devcontainers. For long-term contributions where you prefer local development, you can set up freeCodeCamp on your local machine.
 
-| Feature                     | GitHub Codespaces | Your own machine |
-| --------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------ |
-| **Hardware requirements**   | No minimum hardware requirements                                          | Powerful minimum hardware requirements           |
-| **Software installation**   | No need to install any software                                           | Additional software needed                       |
-| **Repository status**       | Always up-to-date repository                                              | Manual updates required                          |
-| **Setup complexity**        | Easy setup with devcontainers, works in any browser                       | Larger download and setup time                   |
-| **Internet dependency**     | Requires an internet connection to work                                   | Minimal internet connection required once set up |
-| **Performance**             | Consistent cloud-based performance                                        | Depends on your machine capabilities             |
-| **Usage limits**            | 60 hours free per month for personal accounts                             | No usage limits                                  |
-| **Environment consistency** | Identical setup for all contributors via devcontainers                    | May vary between different machines and OS       |
+| Feature                     | GitHub Codespaces                                      | Your own machine                                 |
+| --------------------------- | ------------------------------------------------------ | ------------------------------------------------ |
+| **Hardware requirements**   | No minimum hardware requirements                       | Powerful minimum hardware requirements           |
+| **Software installation**   | No need to install any software                        | Additional software needed                       |
+| **Repository status**       | Always up-to-date repository                           | Manual updates required                          |
+| **Setup complexity**        | Easy setup with devcontainers, works in any browser    | Larger download and setup time                   |
+| **Internet dependency**     | Requires an internet connection to work                | Minimal internet connection required once set up |
+| **Performance**             | Consistent cloud-based performance                     | Depends on your machine capabilities             |
+| **Usage limits**            | 60 hours free per month for personal accounts          | No usage limits                                  |
+| **Environment consistency** | Identical setup for all contributors via devcontainers | May vary between different machines and OS       |
 
 Once you have decided, follow the relevant tab below to continue with the setup.
 

--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -73,7 +73,7 @@ Next, you need to choose between setting up a cloud IDE or your own machine.
 
 If you're looking to make a one-time contribution or want the fastest setup, use GitHub Codespaces which provides a ready-to-code environment in your web browser using devcontainers. For long-term contributions where you prefer local development, you can set up freeCodeCamp on your local machine.
 
-| Feature                     | GitHub Codespaces <Badge text="Recommended" variant="tip" size="small" /> | Your own machine                                 |
+| Feature                     | GitHub Codespaces | Your own machine |
 | --------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------ |
 | **Hardware requirements**   | No minimum hardware requirements                                          | Powerful minimum hardware requirements           |
 | **Software installation**   | No need to install any software                                           | Additional software needed                       |


### PR DESCRIPTION
This removes the “Recommended” badge from GitHub Codespaces in the local setup documentation.
The change reflects current contributor guidance, as Codespaces can be problematic for some first-time contributors.
