### PR TITLE
fix(github): Node.js 24.x for actions

### DIFF
--- a/.github/workflows/re-build.yml
+++ b/.github/workflows/re-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout

--- a/.github/workflows/re-lint.yml
+++ b/.github/workflows/re-lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout source files

--- a/.github/workflows/re-test.yml
+++ b/.github/workflows/re-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
What:
- Updated reusable workflows to run on Node.js 24.x only

Why:
- Dependencies require Node >= 24.12.0
- Prevents CI failures caused by unsupported Node versions
