### PR TITLE
ci: cancel redundant workflow runs using concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build Check
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
What:
- Added concurrency control to cancel in-progress runs for the same ref

Why:
- Prevents redundant CI executions on frequent pushes
- Improves CI efficiency and feedback time
