### PR TITLE
docs: clarify how to assert absence of function calls using Python AST helper

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -1531,6 +1531,17 @@ node.block_has_call("get") # True
 node.block_has_call("split") # False
 ```
 
+### Asserting absence of a function call
+
+Sometimes a challenge requires learners to remove a specific statement, such as a `print()` call.
+
+To assert that a function call does not exist in the learner’s code, simply negate the helper result:
+
+```python
+assert not Node(code).has_call("print()")
+assert not Node(code).block_has_call("print")
+```
+
 #### `has_import()`
 
 ```python


### PR DESCRIPTION
Checklist:

- [x] I have read freeCodeCamp's contribution guidelines.
- [x] My pull request has a descriptive title.

Closes #1121

Adds documentation explaining how to assert the absence of function calls using the Python AST helper. This helps curriculum authors enforce removal of statements such as `print()`.
