### PR TITLE
docs: remove outdated compile:ts references and clarify Turborepo build

### DIFF
--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -295,7 +295,10 @@ npx playwright show-report
 - Create a config file.
 
   ```bash
-  pnpm run compile:ts
+  > Note: The `compile:ts` script is no longer used.
+  > freeCodeCamp now uses Turborepo to compile TypeScript automatically,
+  > so you do not need to run `pnpm run compile:ts` manually.
+
   ```
 
 - Seed the database

--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -292,15 +292,6 @@ npx playwright show-report
   cp sample.env .env
   ```
 
-- Create a config file.
-
-  ```bash
-  > Note: The `compile:ts` script is no longer used.
-  > freeCodeCamp now uses Turborepo to compile TypeScript automatically,
-  > so you do not need to run `pnpm run compile:ts` manually.
-
-  ```
-
 - Seed the database
 
   ```bash

--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -327,7 +327,9 @@ pnpm install
 ```
 
 ```bash
-pnpm run compile:ts
+> Note: The `compile:ts` script is no longer used.
+> freeCodeCamp now uses Turborepo to compile TypeScript automatically,
+> so you do not need to run `pnpm run compile:ts` manually.
 ```
 
 ### Step 3: Start MongoDB and Seed the Database

--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -326,12 +326,6 @@ Install the dependencies and set up shared configuration for services.
 pnpm install
 ```
 
-```bash
-> Note: The `compile:ts` script is no longer used.
-> freeCodeCamp now uses Turborepo to compile TypeScript automatically,
-> so you do not need to run `pnpm run compile:ts` manually.
-```
-
 ### Step 3: Start MongoDB and Seed the Database
 
 Before you can run the application locally, you will need to start a MongoDB Server as a replica set.

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -431,7 +431,9 @@ You only need to follow this section if you're modifying the challenge test runn
 4. Install the dependencies for the freeCodeCamp repo:
 
    ```bash
-   pnpm install && pnpm run compile:ts
+   > Note: The `compile:ts` script is no longer used.
+   > freeCodeCamp now uses Turborepo to compile TypeScript automatically,
+   > so you do not need to run `pnpm run compile:ts` manually.
    ```
 
 5. Generate the challenge data JSON file:

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -431,9 +431,7 @@ You only need to follow this section if you're modifying the challenge test runn
 4. Install the dependencies for the freeCodeCamp repo:
 
    ```bash
-   > Note: The `compile:ts` script is no longer used.
-   > freeCodeCamp now uses Turborepo to compile TypeScript automatically,
-   > so you do not need to run `pnpm run compile:ts` manually.
+   pnpm install
    ```
 
 5. Generate the challenge data JSON file:

--- a/src/content/docs/language-lead-handbook.mdx
+++ b/src/content/docs/language-lead-handbook.mdx
@@ -175,7 +175,7 @@ You will want to [build the translated client locally](/how-to-enable-new-langua
 
 1. Update your `.env` file to use your language for `CLIENT_LOCALE` and `CURRICULUM_LOCALE`.
 
-2. TypeScript is compiled automatically using Turborepo, so you do not need to run `pnpm run compile:ts` manually. The `trending.json` file will be generated during the build process.
+2. Run `pnpm -F=client run create:trending`. This will automatically generate the `trending.json` file for your language under the `/client/i18n/locales/` directory.
 
 3. Start the server by running `pnpm run develop:server` in one terminal window.
 

--- a/src/content/docs/language-lead-handbook.mdx
+++ b/src/content/docs/language-lead-handbook.mdx
@@ -174,10 +174,14 @@ You will want to [build the translated client locally](/how-to-enable-new-langua
 <Steps>
 
 1. Update your `.env` file to use your language for `CLIENT_LOCALE` and `CURRICULUM_LOCALE`.
-2. Run `pnpm run compile:ts`. This will automatically generate the `trending.json` file for your language under the `/client/i18n/locales/` directory.
+
+2. TypeScript is compiled automatically using Turborepo, so you do not need to run `pnpm run compile:ts` manually. The `trending.json` file will be generated during the build process.
+
 3. Start the server by running `pnpm run develop:server` in one terminal window.
+
 4. Edit the `trending.json` to contain the titles you want to preview. You may want to convert your `.yaml` file into JSON format with an automatic tool.
-5. In another terminal window, run `pnpm run clean:client`, and then `pnpm run develop:client`
+
+5. In another terminal window, run `pnpm run clean:client`, and then `pnpm run develop:client`.
 
 </Steps>
 


### PR DESCRIPTION
Fixes outdated documentation references to `pnpm run compile:ts`.

freeCodeCamp now uses Turborepo for TypeScript compilation, so this command is no longer required.  
Updated multiple setup and contributor docs to reduce confusion for new contributors.

Closes #65357

