### PR TITLE
docs: add contextual notes to specialized guides

### DIFF
--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Steps } from '@astrojs/starlight/components';
 
+:::note[When do you need this guide?]
+You'll need this guide if you're adding or modifying end-to-end tests. If you're fixing a typo or updating documentation, you can safely skip this guide.
+:::
+
 ## Installation
 
 To install Playwright run:

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Steps } from '@astrojs/starlight/components';
 
+:::note[When do you need this guide?]
+You'll need this guide if you're contributing to the freeCodeCamp mobile app. If you're working on the main web platform or curriculum, you can safely skip this and follow the [main setup guide](/how-to-setup-freecodecamp-locally/) instead.
+:::
+
 Follow these guidelines for setting up a development environment for freeCodeCamp. This is highly recommended if you want to contribute regularly.
 
 Some of the contribution workflows – like fixing bugs in the codebase – need you to run the freeCodeCamp app locally.

--- a/src/content/docs/how-to-work-on-the-docs-site.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-site.mdx
@@ -14,6 +14,10 @@ import {
   TabItem
 } from '@astrojs/starlight/components';
 
+:::note[When do you need this guide?]
+You'll need this guide if you're contributing to this documentation site (freeCodeCamp's contributing guides). If you're working on curriculum challenges or the learning platform, you can safely skip this guide.
+:::
+
 Follow these guidelines for setting up a development environment for the freeCodeCamp documentation site. This is highly recommended if you want to contribute regularly to our contributing guidelines.
 
 ## Fork the contribute repository on GitHub


### PR DESCRIPTION
Checklist:

- [x] I have read freeCodeCamp's contribution guidelines.
- [x] My pull request has a descriptive title (**not** a vague title like `Update index.md`)

Closes #1141

---

### What changed
This PR adds short contextual notes to a few specialized contribution guides to help new contributors understand:
- when a guide is relevant, and
- when it can be safely skipped.

### Files updated
- `how-to-add-playwright-tests.mdx`
- `how-to-setup-freecodecamp-mobile-app-locally.mdx`
- `how-to-work-on-the-docs-site.mdx`

### Testing
- Verified locally using the dev server
- Confirmed `:::note` blocks render correctly
