### PR TITLE
docs: add that setup is needed after cleaning for challenge editor

### DIFF
--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -44,7 +44,7 @@ These instructions will tell you how to use our challenge editor tool to work on
 
 ### Setting Up the Challenge Editor
 
-The first time you want to use the editor, make sure you are in the root freeCodeCamp directory and run: `pnpm challenge-editor-setup`.
+The first time you want to use the editor, and after you use `clean` commands (like `clean-and-develop`), make sure you are in the root freeCodeCamp directory and run: `pnpm challenge-editor-setup`.
 
 ### Starting the Editor
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The challenge editor needs the `challenge-editor-setup` script after any `clean` script like (`clean-and-develop`) as those remove all `node_modules` folders, including that for the challenge editor, which is needed for its working