### PR TITLE
docs: fix git push command in codebase contribution guide

### DIFF
--- a/src/content/docs/how-to-contribute-to-the-codebase.mdx
+++ b/src/content/docs/how-to-contribute-to-the-codebase.mdx
@@ -218,7 +218,7 @@ Follow these steps:
 10. Next, you can push your changes to your fork:
 
     ```bash
-    git push origin branch/name-here
+    git push origin branch-name-here
     ```
 
 </Steps>


### PR DESCRIPTION
Checklist:

- [x] I have read freeCodeCamp's contribution guidelines(https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title(https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title)

Closes #1202

Changed `git push origin branch/name-here` to `git push origin branch-name-here` 
in Step 10 to avoid confusion for new contributors who might interpret 
`branch/` as part of the command syntax.
