### PR TITLE
fix: change branch/name-here to branch-name-here in git push commands

### DIFF
--- a/src/content/docs/how-to-contribute-to-the-codebase.mdx
+++ b/src/content/docs/how-to-contribute-to-the-codebase.mdx
@@ -218,7 +218,7 @@ Follow these steps:
 10. Next, you can push your changes to your fork:
 
     ```bash
-    git push origin branch/name-here
+    git push origin branch-name-here
     ```
 
 </Steps>

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -388,7 +388,7 @@ Follow these steps:
 10. Next, you can push your changes to your fork:
 
     ```bash
-    git push origin branch/name-here
+    git push origin branch-name-here
     ```
 
 </Steps>


### PR DESCRIPTION
Closes #1202 - Improves clarity for new contributors by using hyphen instead of slash in branch name placeholder.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1202

Improves clarity for new Git users who were confused by the slash notation. The change makes it clearer that they should use their branch name with hyphens, not type "branch/" literally.

Changed in 2 files:

• how-to-contribute-to-the-codebase.mdx
• how-to-setup-freecodecamp-mobile-app-locally.mdx
