### PR TITLE
docs: add contextual descriptions to specialized guides

### DIFF
--- a/src/content/docs/how-to-add-playwright-tests.mdx
+++ b/src/content/docs/how-to-add-playwright-tests.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Steps } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're adding or modifying end-to-end tests, or if your contribution changes user-facing behavior that requires test coverage. If you're only fixing a typo or updating documentation, you can skip this guide.
+:::
+
 ## Installation
 
 To install Playwright run:

--- a/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-mobile-app-locally.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Steps } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're contributing to the freeCodeCamp mobile app. If you're working on the main platform, curriculum, or documentation, you can skip this guide.
+:::
+
 Follow these guidelines for setting up a development environment for freeCodeCamp. This is highly recommended if you want to contribute regularly.
 
 Some of the contribution workflows – like fixing bugs in the codebase – need you to run the freeCodeCamp app locally.

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Steps } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're creating or modifying interactive coding challenges. If you're working on other types of curriculum like workshops, labs, or quizzes, check their respective guides.
+:::
+
 Our goal is to develop a fun and clear interactive learning experience.
 
 Designing interactive coding challenges is difficult. It would be much easier to write a lengthy explanation or to create a video tutorial. But for our core curriculum, we're sticking with what works best for most people - a fully interactive, video game-like experience.

--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -4,6 +4,10 @@ sidebar:
   label: Work on Lab Challenges
 ---
 
+:::tip
+You'll need this guide if you're creating or modifying lab challenges (project-based learning with user stories). If you're working on other types of challenges like workshops, coding projects, or quizzes, check their respective guides.
+:::
+
 Labs are a type of challenge that presents an empty or almost empty editor to the camper, and a list of user stories to satisfy.
 
 Lab descriptions should have this format:

--- a/src/content/docs/how-to-work-on-localized-client-webapp.mdx
+++ b/src/content/docs/how-to-work-on-localized-client-webapp.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Aside, FileTree } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're working on translating or localizing the freeCodeCamp platform into different languages. If you're working on curriculum, documentation, or other areas, you can skip this guide.
+:::
+
 The React-based client web app that powers our learning platform is built using Gatsby. It is translated into various world languages using [react-i18next](https://react.i18next.com/) and [i18next](https://www.i18next.com/).
 
 You can learn more about setting up the client application locally for development by following [our local setup guide here](/how-to-setup-freecodecamp-locally/). By default, the application is available only in English.

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -6,6 +6,10 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're creating or modifying quiz questions for certifications. If you're working on other types of challenges like workshops, labs, or coding projects, check their respective guides.
+:::
+
 We are currently in the process of developing a new format for certifications which will be more rigorous and time consuming than our previous certifications.
 
 Every module of the certification will have a quiz to test camper's knowledge as they move throughout the curriculum.

--- a/src/content/docs/how-to-work-on-reviews.mdx
+++ b/src/content/docs/how-to-work-on-reviews.mdx
@@ -4,6 +4,10 @@ sidebar:
   label: Work on Review Pages
 ---
 
+:::tip
+You'll need this guide if you're creating or modifying review pages that summarize chapter/module topics. If you're working on other types of content like workshops, labs, or quizzes, check their respective guides.
+:::
+
 The reviews summarise the topics introduced in the corresponding chapter or module, in lectures and workshops (as some workshops introduce new concepts not taught in the lectures). Some modules could have more than one review depending on how they are structured.
 
 The concepts in a review should follow this pattern.

--- a/src/content/docs/how-to-work-on-the-component-library.mdx
+++ b/src/content/docs/how-to-work-on-the-component-library.mdx
@@ -4,6 +4,10 @@ sidebar:
   label: Work on Component Library
 ---
 
+:::tip
+You'll need this guide if you're building or modifying user interface components for the freeCodeCamp platform. If you're working on curriculum, documentation, or other areas, you can skip this guide.
+:::
+
 Welcome to freeCodeCamp's `ui` library. The components are built mostly from scratch with basic HTML elements and [Tailwind CSS](https://tailwindcss.com/).
 
 :::note

--- a/src/content/docs/how-to-work-on-the-docs-site.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-site.mdx
@@ -14,6 +14,10 @@ import {
   TabItem
 } from '@astrojs/starlight/components';
 
+:::tip
+You'll need this guide if you're contributing to or improving the freeCodeCamp contributing documentation itself. If you're working on curriculum, codebase, or other areas, you can skip this guide.
+:::
+
 Follow these guidelines for setting up a development environment for the freeCodeCamp documentation site. This is highly recommended if you want to contribute regularly to our contributing guidelines.
 
 ## Fork the contribute repository on GitHub

--- a/src/content/docs/how-to-work-on-tutorials-that-use-coderoad.mdx
+++ b/src/content/docs/how-to-work-on-tutorials-that-use-coderoad.mdx
@@ -4,6 +4,10 @@ sidebar:
   label: Work on tutorials with CodeRoad
 ---
 
+:::tip
+You'll need this guide if you're contributing to tutorials that use the CodeRoad VS Code extension. If you're working on the main freeCodeCamp curriculum or other areas, you can skip this guide.
+:::
+
 This page describes how to contribute to the freeCodeCamp tutorials and projects that are completed using the CodeRoad VS Code extension.
 
 ## How the Tutorials Work

--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -4,6 +4,10 @@ sidebar:
   label: Work on Workshops
 ---
 
+:::tip
+You'll need this guide if you're creating or modifying workshop-style curriculum (step-based learning). If you're working on other types of challenges like coding projects, labs, or quizzes, check their respective guides.
+:::
+
 Our workshops use a step-based approach to teach concepts to campers. A workshop will consist of multiple files, which we refer to as **"steps"**. These files are named by the challenge ID, to avoid issues with the translation flow. Unfortunately, this makes it difficult to find the file associated with a specific step.
 
 We've built a [challenge editor tool](#using-the-challenge-editor) that helps remedy this. This tool allows you to navigate the available workshops, and the steps for each workshop (in order). There's also an embedded code editor you can use to work on the files directly.


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #1141

## Description

Adds introductory tip sections to specialized guide pages explaining when each guide is needed. This helps new contributors understand which guides are relevant to their specific contribution type without feeling overwhelmed.

## Changes Made

Added :::tip callouts to the following files:
- how-to-add-playwright-tests.mdx
- how-to-setup-freecodecamp-mobile-app-locally.mdx
- how-to-work-on-coding-challenges.mdx
- how-to-work-on-labs.mdx
- how-to-work-on-localized-client-webapp.mdx
- how-to-work-on-quizzes.mdx
- how-to-work-on-reviews.mdx
- how-to-work-on-the-component-library.mdx
- how-to-work-on-the-docs-site.mdx
- how-to-work-on-tutorials-that-use-coderoad.mdx
- how-to-work-on-workshops.mdx
