### PR TITLE
docs: link to all specialized content type guides

### DIFF
--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -82,6 +82,7 @@ Our curriculum is curated by the global freeCodeCamp community. You can help exp
    Our main guide for curriculum work: [how to work on coding challenges](/how-to-work-on-coding-challenges/).
 
    > If you're working on a specific content type, check out these specialized guides:
+   >
    > - [Work on workshops](/how-to-work-on-workshops/) - for step-by-step projects
    > - [Work on labs](/how-to-work-on-labs/) - for interactive coding exercises
    > - [Work on quizzes](/how-to-work-on-quizzes/) - for multiple-choice questions

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -81,6 +81,12 @@ Our curriculum is curated by the global freeCodeCamp community. You can help exp
 
    Our main guide for curriculum work: [how to work on coding challenges](/how-to-work-on-coding-challenges/).
 
+   > If you're working on a specific content type, check out these specialized guides:
+   > - [Work on workshops](/how-to-work-on-workshops/) - for step-by-step projects
+   > - [Work on labs](/how-to-work-on-labs/) - for interactive coding exercises
+   > - [Work on quizzes](/how-to-work-on-quizzes/) - for multiple-choice questions
+   > - [Work on reviews](/how-to-work-on-reviews/) - for code review exercises
+
 4. **Understand the curriculum structure**
 
    Review the [curriculum file structure](/curriculum-file-structure/) to understand how content is organized.
@@ -93,7 +99,6 @@ Our curriculum is curated by the global freeCodeCamp community. You can help exp
 
 :::tip[Optional Reading]
 
-- [Work on quizzes](/how-to-work-on-quizzes/), [reviews](/how-to-work-on-reviews/), [labs](/how-to-work-on-labs/), or [workshops](/how-to-work-on-workshops/) - for specific content types
 - [Add Playwright tests](/how-to-add-playwright-tests/) - if adding test coverage for your changes
 - [Curriculum testing helpers](/curriculum-help/) - utilities for testing curriculum content
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -33,6 +33,16 @@ Before you work on the curriculum, you would need to set up some tooling to help
 
   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/freeCodeCamp/freeCodeCamp)
 
+### Other content types
+
+This guide covers the core concepts for all curriculum content types. If you're working on a specific type, you may also need:
+
+- [Work on workshops](/how-to-work-on-workshops/) - step-based projects with multiple steps
+- [Work on labs](/how-to-work-on-labs/) - interactive coding exercises
+- [Work on quizzes](/how-to-work-on-quizzes/) - multiple-choice questions
+- [Work on reviews](/how-to-work-on-reviews/) - code review exercises
+- [Work on tutorials that use CodeRoad](/how-to-work-on-tutorials-that-use-coderoad/) - tutorial-based learning
+
 ### How to work on workshops
 
 The workshops have some additional tooling to help create new projects and steps. To read more, see [these docs](/how-to-work-on-workshops/)


### PR DESCRIPTION
## Description

This PR addresses issue #1229 by reorganising the documentation to reduce overwhelm and help contributors find the right guide for their contribution type.

## Changes

### getting-started.mdx
- Added inline callouts in the main Curriculum & Challenges workflow pointing to specialized guides (workshops, labs, quizzes, reviews)
- Removed duplicate links from Optional Reading section

### how-to-work-on-coding-challenges.mdx
- Added new "Other content types" section listing all specialized guides
- Kept existing workshops link in its own subsection

This makes it easier for new contributors to discover the right guide without feeling overwhelmed by the main coding challenges page.

## Checklist

- [x] I have read freeCodeCamp contribution guidelines
- [x] My pull request has a descriptive title

Closes #1229