### PR TITLE
docs: replace blockType with blockLabel in workshop, lab, and review docs

### DIFF
--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -38,4 +38,4 @@ For the labs that do not have a demo project, the solution can be the minimum ne
 
 The labs that have a demo project have a `demoType` property in the frontmatter with a value of `onClick`, the labs that do not have a demo project do not have a `demoType` project.
 
-The metadata for labs require a `blockType` property with a value of `lab`, and a `blockLayout` with a value of `link`.
+The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`.

--- a/src/content/docs/how-to-work-on-reviews.mdx
+++ b/src/content/docs/how-to-work-on-reviews.mdx
@@ -30,7 +30,7 @@ The topics can be divided in sections using headings, headings should start from
 ### Sub topic (if needed)
 ```
 
-The metadata for reviews require a `blockType` property with a value of `review`, and a `blockLayout` with a value of `link`.
+The metadata for reviews require a `blockLabel` property with a value of `review`, and a `blockLayout` with a value of `link`.
 
 Reviews use a `challengeType` of 31.
 

--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -40,7 +40,7 @@ Some workshops, which are debugging workshop, will be called `Debugging a ...` a
 
 You can create the workshop with `pnpm run create-new-project`.
 
-The metadata for workshops require a `blockType` property with a value of `workshop`, and a `blockLayout` with a value of `challenge-grid`.
+The metadata for workshops require a `blockLabel` property with a value of `workshop`, and a `blockLayout` with a value of `challenge-grid`.
 
 ## Using the Challenge Editor
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #1238

Updated the documentation to replace the outdated `blockType` field with `blockLabel` in the following files:

- `src/content/docs/how-to-work-on-workshops.mdx`
- `src/content/docs/how-to-work-on-labs.mdx`
- `src/content/docs/how-to-work-on-reviews.mdx`

This aligns the docs with the current field name used in the codebase. 

I also ran `npm run lint`, and the reported errors were in `src/content.config.ts`, which appears unrelated to the documentation changes in this PR.