### PR TITLE
docs: update curriculum file structure page and link it from workshops and labs guides

### DIFF
--- a/src/content/docs/curriculum-file-structure.mdx
+++ b/src/content/docs/curriculum-file-structure.mdx
@@ -14,6 +14,8 @@ There are a few terms we use when discussing our curriculum content.
 
 - `certification` : When referring to a certification in this instance, it is talking about the actual certificate that users claim. Which is separate from the name of the superBlock.
 - `superBlock` : A superblock is the top level collection of challenges. Each superblock corresponds to a certification in the curriculum (e.g. Responsive Web Design).
+- `chapter` : A chapter is a grouping of modules within a superblock. Not all superblocks use chapters; legacy superblocks organize blocks in a flat list instead.
+- `module` : A module is a grouping of blocks within a chapter.
 - `block` : A block is a section within a superblock. A block corresponds to a group of challenges in a given certification (e.g. Basic HTML and HTML5)
 - `challenge` : A challenge is a single lesson within the curriculum (e.g. Say Hello to HTML Elements)
 
@@ -110,24 +112,47 @@ More complex superblocks can organize blocks into chapters and modules for bette
 }
 ```
 
+Modules and chapters can have additional properties that affect how they are treated:
+
+- **`moduleType: "cert-project"`**: A module containing a single certification project block.
+- **`moduleType: "review"`**: A module containing a review block.
+- **`comingSoon: true`**: Marks a module as not yet available to campers.
+- **`chapterType: "exam"`**: Marks a chapter as containing the certification exam.
+
 ### blocks/&lt;block&gt;.json
 
 Each block has its own JSON file that contains metadata and the order of challenges:
 
 ```json
 {
-  "name": "Basic HTML and HTML5",
+  "name": "Build a Greeting Bot",
+  "dashedName": "workshop-greeting-bot",
+  "blockLabel": "workshop",
+  "blockLayout": "challenge-grid",
+  "helpCategory": "JavaScript",
   "isUpcomingChange": false,
-  "dashedName": "basic-html-and-html5",
-  "helpCategory": "HTML-CSS",
+  "usesMultifileEditor": true,
+  "hasEditableBoundaries": true,
   "challengeOrder": [
     {
-      "id": "bd7123c8c441eddfaeb5bdef",
-      "title": "Say Hello to HTML Elements"
+      "id": "66ad8294a0ad902f1b31b612",
+      "title": "Step 1"
     }
   ]
 }
 ```
+
+Key fields:
+
+- **`name`**: Display name of the block.
+- **`dashedName`**: URL-friendly slug for the block.
+- **`blockLabel`**: The label shown on the block card. Common values are `workshop`, `lab`, `lecture`, `review`, `quiz`, `exam`, `warm-up`, `learn`, and `practice`. Legacy blocks do not have this field.
+- **`blockLayout`**: Controls how the block is displayed. Common values include `challenge-grid`, `challenge-list`, and `legacy-challenge-list`.
+- **`helpCategory`**: Determines which forum subforum is used when a camper requests help via the help button (e.g. `JavaScript`, `HTML-CSS`, `Python`).
+- **`isUpcomingChange`**: When `true`, hides the block from campers until it is ready.
+- **`usesMultifileEditor`**: When `true`, the challenge editor shows multiple files.
+- **`hasEditableBoundaries`**: When `true`, part of the code is highlighted to indicate where changes should be made.
+- **`challengeOrder`**: Ordered list of `{ id, title }` objects defining the sequence of challenges in the block. Challenge files in `curriculum/challenges/english/blocks/<block>/` are named after their `id` (e.g. `66ad8294a0ad902f1b31b612.md`).
 
 ## The Certifications Directory
 
@@ -139,6 +164,40 @@ Each certification YAML file includes the following key properties:
 - **`title`**: Display name of the certification
 - **`certification`**: Internal name used to reference the certification
 - **`tests`**: Array of required projects with their IDs and titles
+
+## The `intro.json` File
+
+The file `client/i18n/locales/english/intro.json` contains the display titles and introductory text shown to campers for each superblock and block. It is organized by superblock, then by block:
+
+```json
+{
+  "javascript-v9": {
+    "title": "JavaScript Certification",
+    "intro": ["..."],
+    "chapters": {
+      "javascript": "JavaScript",
+      "javascript-certification-exam": "JavaScript Certification Exam"
+    },
+    "modules": {
+      "javascript-variables-and-strings": "Variables and Strings"
+    },
+    "module-intros": {
+      "data-structures": {
+        "note": "Coming Spring 2026",
+        "intro": ["..."]
+      }
+    },
+    "blocks": {
+      "workshop-greeting-bot": {
+        "title": "Build a Greeting Bot",
+        "intro": ["..."]
+      }
+    }
+  }
+}
+```
+
+`chapters` and `modules` are only present in new-style superblocks. `module-intros` contains introductory text for modules marked as `comingSoon` in the structure file. Legacy superblocks only have `title`, `intro`, and `blocks`.
 
 ## Internationalization Structure
 

--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -38,4 +38,4 @@ For the labs that do not have a demo project, the solution can be the minimum ne
 
 The labs that have a demo project have a `demoType` property in the frontmatter with a value of `onClick`, the labs that do not have a demo project do not have a `demoType` project.
 
-The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`.
+The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`. For an overview of how blocks fit into the broader curriculum hierarchy, refer to the [curriculum file structure](/curriculum-file-structure/) page.

--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -38,7 +38,7 @@ Workshop titles start with "Build a" or "Design a", followed by the name of the 
 
 Some workshops, which are debugging workshop, will be called `Debugging a ...` and have prefix `workshop-debugging` in the `dashedName`.
 
-You can create the workshop with `pnpm run create-new-project`.
+You can create the workshop with `pnpm run create-new-project`. The CLI will ask you which certification, chapter, module, and position the workshop belongs to. If you are unsure about these concepts, refer to the [curriculum file structure](/curriculum-file-structure/) page.
 
 The metadata for workshops require a `blockLabel` property with a value of `workshop`, and a `blockLayout` with a value of `challenge-grid`.
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Related to #1200.

Contributors working on workshops and labs are asked to select a certification, chapter, module, and position during `pnpm run create-new-project`, but the current docs don't explain what those concepts mean. This PR expands the curriculum file structure page with the missing terminology and field descriptions, and links to it from the workshops and labs guides at the point where that knowledge is needed.