### PR TITLE
docs: update curriculum file structure docs for block name and intro.json changes

### DIFF
--- a/src/content/docs/curriculum-file-structure.mdx
+++ b/src/content/docs/curriculum-file-structure.mdx
@@ -125,7 +125,6 @@ Each block has its own JSON file that contains metadata and the order of challen
 
 ```json
 {
-  "name": "Build a Greeting Bot",
   "dashedName": "workshop-greeting-bot",
   "blockLabel": "workshop",
   "blockLayout": "challenge-grid",
@@ -144,8 +143,7 @@ Each block has its own JSON file that contains metadata and the order of challen
 
 Key fields:
 
-- **`name`**: Display name of the block.
-- **`dashedName`**: URL-friendly slug for the block.
+- **`dashedName`**: URL-friendly slug for the block. The display name of the block is defined in [`intro.json`](#the-introjson-file) under the block's `title` field.
 - **`blockLabel`**: The label shown on the block card. Common values are `workshop`, `lab`, `lecture`, `review`, `quiz`, `exam`, `warm-up`, `learn`, and `practice`. Legacy blocks do not have this field.
 - **`blockLayout`**: Controls how the block is displayed. Common values include `challenge-grid`, `challenge-list`, and `legacy-challenge-list`.
 - **`helpCategory`**: Determines which forum subforum is used when a camper requests help via the help button (e.g. `JavaScript`, `HTML-CSS`, `Python`).
@@ -196,6 +194,8 @@ The file `client/i18n/locales/english/intro.json` contains the display titles an
   }
 }
 ```
+
+At the superblock level, `title` is the display name of the superblock, and `intro` is the introductory text shown on the superblock page.
 
 `chapters` and `modules` are only present in new-style superblocks. `module-intros` contains introductory text for modules marked as `comingSoon` in the structure file. Legacy superblocks only have `title`, `intro`, and `blocks`.
 
@@ -323,16 +323,13 @@ Also, you will likely want to rename the certificate and the `<superBlock>-proje
      "destination": "/learn/new-superblock-name/:block?/:challenge?"
    }
    ```
-5. Rename the superblock folder in `client/src/pages/learn`.
-6. Update the `index.md` file in the renamed superblock folder, changing the `title` and `superBlock` values to the new name.
-7. For each block folder within the above, update the `index.md` to use the correct `superBlock` value.
-8. In the `client/src/resources/cert-and-project-map.ts` file, update the path for the cert at the top of the file, and the `title` value for that superBlock. (Note: Changing the `title` here **will break** the ability to view the actual certification for this superBlock. It relies on the superBlock title to match the certification title. You will likely want to rename the certification at the same time.)
-9. Update the `superBlockCertTypeMap` key in `shared/config/certification-settings.js` to the new superBlock name.
-10. Update the path value in `client/src/assets/icons/index.tsx`.
-11. For each language in `client/i18n/locales`, update the `intro.json` file to use the new superBlock `dashedName`. In the English file, also update the `title`.
-12. Check the `shared/config/i18n/all-langs.js` file to see if the superBlock is enabled in i18n builds. Update all the values where it is used.
-13. Update the `superBlockNames` map in `curriculum/build-curriculum.js`. This map links superblock filenames (keys) to certification names (values) - update the key if the superblock filename changed, and update the value if the certification name changed.
-14. Update the main `README.md` file to the new name.
+5. In the `client/src/resources/cert-and-project-map.ts` file, update the path for the cert at the top of the file, and the `title` value for that superBlock. (Note: Changing the `title` here **will break** the ability to view the actual certification for this superBlock. It relies on the superBlock title to match the certification title. You will likely want to rename the certification at the same time.)
+6. Update the `superBlockCertTypeMap` key in `shared/config/certification-settings.js` to the new superBlock name.
+7. Update the path value in `client/src/assets/icons/index.tsx`.
+8. For each language in `client/i18n/locales`, update the `intro.json` file to use the new superBlock `dashedName`. In the English file, also update the `title`.
+9. Check the `shared/config/i18n/all-langs.js` file to see if the superBlock is enabled in i18n builds. Update all the values where it is used.
+10. Update the `superBlockNames` map in `curriculum/build-curriculum.js`. This map links superblock filenames (keys) to certification names (values) - update the key if the superblock filename changed, and update the value if the certification name changed.
+11. Update the main `README.md` file to the new name.
 
 </Steps>
 
@@ -344,7 +341,7 @@ When renaming a curriculum block, you need to:
 
 1. Change the name of the block folder in the `curriculum/challenges/english/blocks/<block>` directory.
 2. Rename the block's JSON file in `curriculum/structure/blocks/` from `<old-name>.json` to `<new-name>.json`.
-3. Update the `name` and `dashedName` properties in the renamed block JSON file.
+3. Update the `dashedName` property in the renamed block JSON file.
 4. Update the superblock's JSON file in `curriculum/structure/superblocks/` to reference the new block name in its `blocks` array.
 5. [**Add redirects** to the `serve.json` file](#setting-up-redirects) to redirect from old block URLs to new ones:
    ```json
@@ -353,10 +350,8 @@ When renaming a curriculum block, you need to:
      "destination": "/learn/superblock-name/new-block-name/:challenge?"
    }
    ```
-6. Update the block folder in `client/src/pages/learn/<superBlock>`.
-7. In the `index.md` file of the above folder, update the `block` value in the frontmatter.
-8. In the `client/i18n/locales/<language>/intro.json` files, update the block name to the new name for all the languages. In the English `intro.json` file, update the `title` as well.
-9. Update the main `README.md` file to the new name.
+6. In the `client/i18n/locales/<language>/intro.json` files, update the block name to the new name for all the languages. In the English `intro.json` file, update the `title` as well.
+7. Update the main `README.md` file to the new name.
 
 </Steps>
 

--- a/src/content/docs/how-to-create-catalog-items.mdx
+++ b/src/content/docs/how-to-create-catalog-items.mdx
@@ -57,31 +57,28 @@ exist.
 10. Add challenge files in the block.  
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/learn-python-setup-first-steps/learn-python-intro-video.md)
 
-11. Add the superblock page file.  
-    [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/pages/learn/learn-python-for-beginners/index.md)
-
-12. Add the translation string for the superblock.  
+11. Add the translation string for the superblock.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/i18n/locales/english/translations.json)
 
-13. Add the intro title and summary.  
+12. Add the intro title and summary.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/i18n/locales/english/intro.json)
 
-14. Add the catalog entry and a topic if the topic is new.  
+13. Add the catalog entry and a topic if the topic is new.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/packages/shared/src/config/catalog.ts)
 
-15. Add the superblock to the catalog stage list.  
+14. Add the superblock to the catalog stage list.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/packages/shared/src/config/curriculum.ts)
 
-16. Add the superblock icon.  
+15. Add the superblock icon.
     [Example](https://github.com/ahmaxed/freeCodeCamp/blob/main/client/src/assets/superblock-icon.tsx)
 
-17. Add label styling for new topics.  
+16. Add label styling for new topics.
     [Example](https://github.com/ahmaxed/freeCodeCamp/blob/main/client/src/templates/Introduction/intro.css)
 
-18. Keep the catalog test in sync.  
+17. Keep the catalog test in sync.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/packages/shared/src/config/catalog.test.ts)
 
-19. Ensure the catalog page imports catalog config.  
+18. Ensure the catalog page imports catalog config.
     [Example](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/pages/catalog.tsx)
 
 </Steps>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #XXXXX

Updates the curriculum file structure docs to reflect changes introduced in freeCodeCamp/freeCodeCamp#66415:

- Remove `name` field from the `<block>.json` example and key fields list; add a note that the block display name comes from `intro.json`
- Add a note that the superblock `title` and `intro` fields in `intro.json` are the display name and introductory text shown on the superblock page

There were also some references to index.md remaining, so also: 
- Remove references to `index.md` files from the "Renaming a Superblock" and "Renaming a Block" steps
- Remove the "Add the superblock page file" step from `how-to-create-catalog-items.mdx` and renumber the remaining steps
