### PR TITLE
docs: update labs, quizzes, and reviews guides

### DIFF
--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to work on lab challenges
+title: How to Work on Lab Challenges
 sidebar:
   label: Work on Lab Challenges
 ---
@@ -40,7 +40,11 @@ For the labs that do not have a demo project, the solution can be the minimum ne
 
 Labs that have a visual output (i.e. HTML-based) can have a demo project, in which case the frontmatter includes `demoType: onClick`. It is not mandatory, if the project design does not require it it can be omitted.
 
-The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`. For an overview of how blocks fit into the broader curriculum hierarchy, refer to the [curriculum file structure](/curriculum-file-structure/) page.
+## Create the Lab
+
+You can create the lab with `pnpm run create-new-project`. The CLI will ask you which certification, chapter, module, and position the lab belongs to. If you are unsure about these concepts, refer to the [curriculum file structure](/curriculum-file-structure/) page.
+
+The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`.
 
 ## Lab File Template
 

--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -46,6 +46,8 @@ You can create the lab with `pnpm run create-new-project`. The CLI will ask you 
 
 The metadata for labs require a `blockLabel` property with a value of `lab`, and a `blockLayout` with a value of `link`.
 
+Labs have a dashedName starting with `lab-`, and titles follow the format "Build / Implement / Design / Debug [Name]".
+
 ## Lab File Template
 
 Each lab is a single Markdown file. The `challengeType` and seed language depend on the type of lab:

--- a/src/content/docs/how-to-work-on-quizzes.mdx
+++ b/src/content/docs/how-to-work-on-quizzes.mdx
@@ -28,6 +28,10 @@ The core team will be responsible for creating new quizzes for the certification
 
 To create a new quiz, run `pnpm run create-new-quiz` in a command prompt at the root of the project. This will add the necessary boilerplate files for quizzes.
 
+The metadata for quizzes require a `blockLabel` property with a value of `quiz`, and a `blockLayout` with a value of `link`.
+
+Quizzes have a dashedName starting with `quiz-`, and titles follow the format `<Topic> Quiz`.
+
 ## Multiple sets of questions
 
 Most quizzes will have multiple sets of questions that campers can go through. This is to ensure that campers
@@ -132,10 +136,14 @@ const developer = 'Jessica';
 developer[3];
 ```
 
+---
+
 ```js
 const developer = 'Jessica';
 developer[-1];
 ```
+
+---
 
 ```js
 const developer = 'Jessica';

--- a/src/content/docs/how-to-work-on-reviews.mdx
+++ b/src/content/docs/how-to-work-on-reviews.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to work on review pages
+title: How to Work on Review Pages
 sidebar:
   label: Work on Review Pages
 ---
@@ -30,9 +30,13 @@ The topics can be divided in sections using headings, headings should start from
 ### Sub topic (if needed)
 ```
 
-The metadata for reviews require a `blockLabel` property with a value of `review`, and a `blockLayout` with a value of `link`.
-
 Reviews use a `challengeType` of 31.
+
+## Create the Review
+
+You can create the review with `pnpm run create-new-project`. The CLI will ask you which certification, chapter, module, and position the review belongs to. If you are unsure about these concepts, refer to the [curriculum file structure](/curriculum-file-structure/) page.
+
+The metadata for reviews require a `blockLabel` property with a value of `review`, and a `blockLayout` with a value of `link`.
 
 Reviews have a dashedName with `review-topic`, and titles of the reviews are like `Topic Review`.
 
@@ -75,7 +79,69 @@ dashedName: review-topic-name
 Review the [topic] topics and concepts.
 ````
 
-For CSS and JS examples, include the HTML file inside the same `:::interactive_editor` block. The HTML file must explicitly link to the CSS and/or the JS files, they are not linked automatically:
+The `:::interactive_editor` block takes different forms depending on the file types involved.
+
+For JavaScript-only examples (no DOM manipulation):
+
+````md
+:::interactive_editor
+
+```js
+// interactive code example campers can run
+```
+
+:::
+````
+
+When an example involves HTML, include all the relevant files inside the same `:::interactive_editor` block. Files are not linked automatically: the HTML file must explicitly link to any CSS or JavaScript files using a `<link>` or `<script>` tag.
+
+For HTML-only examples:
+
+````md
+:::interactive_editor
+
+```html
+<p>Example content.</p>
+```
+
+:::
+````
+
+For CSS examples, link the CSS file with a `<link>` tag in the HTML:
+
+````md
+:::interactive_editor
+
+```html
+<link rel="stylesheet" href="styles.css" />
+<!-- HTML content -->
+```
+
+```css
+/* CSS styles */
+```
+
+:::
+````
+
+For JavaScript DOM examples, link the JS file with a `<script>` tag in the HTML:
+
+````md
+:::interactive_editor
+
+```html
+<!-- HTML content -->
+<script src="index.js"></script>
+```
+
+```js
+// JavaScript code
+```
+
+:::
+````
+
+For examples with HTML, CSS, and JavaScript, include all three files:
 
 ````md
 :::interactive_editor


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Updates the labs, quizzes, and reviews contributor guides, paired with #1259:

- Fixed page title capitalization for labs and reviews
- Added "Create" section with `pnpm run create-new-project`, `blockLabel`/`blockLayout` metadata, and a link to the curriculum file structure page for labs and reviews
- Added `blockLabel`/`blockLayout` metadata and dashedName/title format conventions (`quiz-<topic>` / `<Topic> Quiz`) under "Creating a new quiz"
- Fixed missing `---` separators between distractor code blocks in the example for quiz
- Expanded the `:::interactive_editor` documentation for reviews to cover all file-type combinations: JS-only, HTML-only, HTML+CSS, HTML+JS DOM, and HTML+CSS+JS (previously only the full three-file case was documented)
