### PR TITLE
fix: typos in documentation

### DIFF
--- a/src/content/docs/authors-analytics-manual.mdx
+++ b/src/content/docs/authors-analytics-manual.mdx
@@ -33,7 +33,7 @@ screen class`.
 
 After arriving at the `Pages and Screens` reports mentioned above, use the following steps to filter the results by specific authors.
 
-![Image - Show steps to search by language on googla analytics](https://contribute.freecodecamp.org/images/google-analytics/filter-by-author.png)
+![Image - Show steps to search by language on Google Analytics](https://contribute.freecodecamp.org/images/google-analytics/filter-by-author.png)
 
 <Steps>
 

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -96,7 +96,7 @@ await __helpers.retryingTest(callback, numberOfTries);
 
 `retryingTest` consider the test passed if the `callback` returns a truthy value, and failed if it returns a falsy value.
 
-This helper is useful in a situation in which the thing being tested could have a delay happening, like having data from an API written on the page. Then, the `callback` is called up to `numberOfTries` or until it succeds, whatever comes first. If there is never a success, then the test fails.
+This helper is useful in a situation in which the thing being tested could have a delay happening, like having data from an API written on the page. Then, the `callback` is called up to `numberOfTries` or until it succeeds, whatever comes first. If there is never a success, then the test fails.
 
 It needs to be used sparingly, because it causes the tests to take a long time.
 

--- a/src/content/docs/how-to-create-catalog-items.mdx
+++ b/src/content/docs/how-to-create-catalog-items.mdx
@@ -21,7 +21,7 @@ These units could be created from existing blocks, or new blocks, or a mix of bo
 
 ## Creating catalog items from new blocks
 
-The followings are all the steps needed to create a new catalog item. Skip the
+The following are all the steps needed to create a new catalog item. Skip the
 block and challenge file creation steps if block and challenge files already
 exist.
 

--- a/src/content/docs/how-to-work-on-labs.mdx
+++ b/src/content/docs/how-to-work-on-labs.mdx
@@ -38,7 +38,7 @@ All labs have a solution, but not all labs have a demo project.
 For the labs that do not have a demo project, the solution can be the minimum necessary to make sure the tests are working correctly.
 :::
 
-Labs that have a visual output (i.e. HTML-based) can have a demo project, in which case the frontmatter includes `demoType: onClick`. It is not mandatory, if the project design does not require it it can be omitted.
+Labs that have a visual output (i.e. HTML-based) can have a demo project, in which case the frontmatter includes `demoType: onClick`. It is not mandatory, if the project design does not require it, it can be omitted.
 
 ## Create the Lab
 

--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -228,7 +228,7 @@ Each step in a workshop is a Markdown file named after its challenge `id`. The `
 
 All step files use exactly two `--fcc-editable-region--` markers in the seed to highlight where campers should make changes. Only the last step requires a `# --solutions--` section.
 
-The `demoType: onLoad` field is only present in the first step, and only for workshops that have a visual output (i.e. HTML-based). It is not mandatory, if the project design does not require it it can be omitted.
+The `demoType: onLoad` field is only present in the first step, and only for workshops that have a visual output (i.e. HTML-based). It is not mandatory, if the project design does not require it, it can be omitted.
 
 Here is the template for a JavaScript workshop step:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

Fixed a couple more typos and grammar issues in the documentation