### PR TITLE
docs: clarify & improve wording of Workshop doc

### DIFF
--- a/src/content/docs/how-to-work-on-workshops.mdx
+++ b/src/content/docs/how-to-work-on-workshops.mdx
@@ -7,7 +7,7 @@ sidebar:
 import HooksShared from './_hooks-shared.mdx';
 
 :::tip
-You'll need this guide if you're creating or modifying workshop-style curriculum (step-based learning). If you're working on other types of challenges like coding projects, labs, or quizzes, check their respective guides.
+You'll need this guide if you're creating or modifying workshop-style curriculum (step-based learning). If you're working on other types of projects like lectures, labs, or quizzes, check their respective guides.
 :::
 
 Our workshops use a step-based approach to teach concepts to campers. A workshop will consist of multiple files, which we refer to as **"steps"**. These files are named by the challenge ID, to avoid issues with the translation flow. Unfortunately, this makes it difficult to find the file associated with a specific step.
@@ -16,7 +16,7 @@ We've built a [challenge editor tool](#using-the-challenge-editor) that helps re
 
 ## Styling pointers
 
-Workshops should alternate steps in which new concepts are introduced small piece by piece, and steps where there is freedom of implementation.
+Workshops should alternate steps in which new concepts are introduced piece by piece, and steps where there is freedom of implementation.
 
 Instructions should always be written using second person, and the hints usually use a format like "You should have...", or "This thing should be/have/do/return...".
 
@@ -62,9 +62,9 @@ The client will run on port `3300`, so you can access it at `http://localhost:33
 
 The default view will list the available `superblocks` - these are the certifications. Click on the certification link you want to work on.
 
-This will take you to the list of blocks. These are the workshops. Click on the workshop link you want to work on.
+This will take you to the list of chapters. Click on one of these to be shown a list of modules. Then click on one of these to be shown a list of blocks. The blocks are the workshops. Click on the workshop link you want to work on.
 
-This will take you to a list of steps for the project. If you are working on an existing step, you can click on the step link to open the editor. If you are adding or removing steps, click the `Use the step tools` link to switch to the step tools for that challenge.
+This will take you to a list of steps for the workshop. If you are working on an existing step, you can click on the step link to open the editor. If you are adding or removing steps, click the `Use the step tools` link to switch to the step tools for that challenge.
 
 ### Editing Steps
 
@@ -78,15 +78,15 @@ You'll need to use `git` manually to stage and commit your files - this tool wil
 
 ### Step Tools
 
-When you click the `Use the step tools` link, you'll be taken to the step tools page. This allows you to add or remove steps from the project.
+When you click the `Use the step tools` link, you'll be taken to the step tools page. This allows you to add or remove steps from the workshop.
 
 #### Create Next Step
 
-Clicking this button will add a new step at the end of the project. This step will use the previous step's code as the seed.
+Clicking this button will add a new step at the end of the workshop. This step will use the previous step's code as the seed.
 
 #### Create Empty Steps
 
-Enter the number of steps you want to add in the input. Then, clicking the button will create many empty steps at the end of the project.
+Enter the number of steps you want to add in the input. Then, clicking the button will create many empty steps at the end of the workshop.
 
 #### Insert Step
 
@@ -106,19 +106,19 @@ If you want to work on the steps manually, in your local IDE, you can run the st
 
 The `tools/challenge-helper-scripts` folder contains tools to help facilitate the creation and maintenance of the freeCodeCamp project-based curriculum.
 
-### Create a New Project
+### Create a New Workshop
 
-Run `pnpm run create-new-project`. This opens up a command line UI that guides you through the process. Once that has finished, there should be a new challenge in the English curriculum that you can use for the first step of the project. For example, if you created a project called `test-project` in the Responsive Web Design certification, it would be in `curriculum/challenges/english/blocks/test-project`.
+Run `pnpm run create-new-project` as described in [Create the workshop](#create-the-workshop). This opens up a command line UI that guides you through the process. Once that has finished, there should be a new challenge in the English curriculum that you can use for the first step of the workshop. For example, if you created a workshop called `workshop-abc` in the Responsive Web Design certification, it would be in `curriculum/challenges/english/blocks/workshop-abc`.
 
 If you want to create new steps, the following tools simplify that process.
 
 ### create-next-step
 
-A one-off script that will automatically add the next step based on the last step in the project. The challenge seed code will use the previous step's challenge seed code.
+A one-off script that will automatically add the next step based on the last step in the workshop. The challenge seed code will use the previous step's challenge seed code.
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -135,7 +135,7 @@ This script also runs [update-step-titles](#update-step-titles).
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -152,7 +152,7 @@ This script also runs [update-step-titles](#update-step-titles).
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -169,7 +169,7 @@ This script also runs [update-step-titles](#update-step-titles).
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -178,11 +178,11 @@ pnpm run delete-step X # where X is the step number to be deleted.
 
 ### update-step-titles
 
-A one-off script that automatically updates the frontmatter in a project's markdown files so that they are consistent with the block's JSON structure file. It ensures that each step's title (and dashedName) matches the block structure's `challengeOrder`.
+A one-off script that automatically updates the frontmatter in a workshop's markdown files so that they are consistent with the block's JSON structure file. It ensures that each step's title (and dashedName) matches the block structure's `challengeOrder`.
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -191,11 +191,11 @@ pnpm run update-step-titles
 
 ### repair-meta
 
-One-off script to parse the step names from the project and update the block's JSON structure file order to reflect those steps. Useful if you've accidentally lost the changes to the block structure file when adding/removing steps.
+One-off script to parse the step names from the workshop and update the block's JSON structure file order to reflect those steps. Useful if you've accidentally lost the changes to the block structure file when adding/removing steps.
 
 #### How to Run the Script
 
-1. Change to the directory of the project.
+1. Change to the directory of the workshop.
 2. Run the following command:
 
 ```bash
@@ -204,7 +204,7 @@ pnpm run repair-meta
 
 ### rename-challenges
 
-The script is to be used if the step-based project has files that have challenges ids and filenames that do not match.
+The script is to be used if the step-based workshop has files that have challenge ids and filenames that do not match.
 
 #### How to Run the Script
 
@@ -228,7 +228,7 @@ Each step in a workshop is a Markdown file named after its challenge `id`. The `
 
 All step files use exactly two `--fcc-editable-region--` markers in the seed to highlight where campers should make changes. Only the last step requires a `# --solutions--` section.
 
-The `demoType: onLoad` field is only present in the first step, and only for workshops that have a visual output (i.e. HTML-based). It is not mandatory, if the project design does not require it, it can be omitted.
+The `demoType: onLoad` field is only present in the first step, and only for workshops that have a visual output (i.e. HTML-based). It is not mandatory, if the workshop design does not require it, it can be omitted.
 
 Here is the template for a JavaScript workshop step:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

N/A

<!-- Feel free to add any additional description of changes below this line -->

I noticed that the contribution guide section titled "How to Work on Workshops" has a few inconsistencies. 
<https://contribute.freecodecamp.org/how-to-work-on-workshops/>

Here's a list of the corrections I found were needed (one of these were discussed with @majestic-owl448 and one with @naomi-lgbt and some were found after I started working on this PR)

1- the command to create-new-project is actually mentioned twice.
  ## First time it is mentioned:
  
  > Create the workshop
  
  > Workshops will have a dashedName of the kind workshop-cat-photo-app, that is the word workshop followed by the name of the app that is being built.
  > 
  > Workshop titles start with “Build a” or “Design a”, followed by the name of the app.
  > 
  > Some workshops, which are debugging workshop, will be called Debugging a ... and have prefix workshop-debugging in the dashedName.
  > 
  > You can create the workshop with pnpm run create-new-project. The CLI will ask you which certification, chapter, module, and position the workshop belongs to. If you are unsure about these concepts, refer to the curriculum file structure page.
  > 
  > The metadata for workshops require a blockLabel property with a value of workshop, and a blockLayout with a value of challenge-grid.
  
  ## And second time:
  > Create a New Project
  
  > Run pnpm run create-new-project. This opens up a command line UI that guides you through the process. Once that has finished, there should be a new challenge in the English curriculum that you can use for the first step of the project. For example, if you created a project called test-project in the Responsive Web Design certification, it would be in curriculum/challenges/english/blocks/test-project.
  > 
  > If you want to create new steps, the following tools simplify that process.
  
  I found the dual mentions w.r.t the workshop creation and the 'project' creation confusing. Therefore I rewrote the 2nd mention to refer to the first one (to make it clear it was actually the same exact step).

2- The use of the word 'project' seemed to almost always mean 'workshop'. So I replaced all occurances that were not part the create-new-project command statement.

3- The description of the Challenge Editor was not complete as it missed the chapter+module levels.

4- There was an awkward phrase that needed to be rewritten which was this one:
" new concepts are introduced small piece by piece"

I removed the word 'small' so that it now reads:
"  new concepts are introduced piece by piece"

