### PR TITLE
fix: add theme-aware styles to prevent initial white flash

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,6 +5,20 @@ import starlightScrollToTop from 'starlight-scroll-to-top';
 import starlightLinksValidator from 'starlight-links-validator';
 import sidebar from './src/sidebar';
 
+const firstPaintThemeStyle = `
+@layer sl-first-paint {
+  html {
+    background-color: #161724;
+    color-scheme: dark;
+  }
+
+  html[data-theme='light'] {
+    background-color: #ffffff;
+    color-scheme: light;
+  }
+}
+`;
+
 const config = defineConfig({
   // @ts-expect-error - Vite 6/7 plugin type incompatibility: Astro 5 uses Vite 6, @tailwindcss/vite 4.1.14 uses Vite 7
   vite: { plugins: [tailwindcss()] },
@@ -26,6 +40,12 @@ const config = defineConfig({
       editLink: {
         baseUrl: 'https://github.com/freeCodeCamp/contribute/edit/main/'
       },
+      head: [
+        {
+          tag: 'style',
+          content: firstPaintThemeStyle
+        }
+      ],
       social: [
         {
           label: 'GitHub',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I noticed a brief white flash when navigating between pages.

Cause:
- The page background depends on CSS variables declared in an external stylesheet. 
- During page navigation, the browser can paint the new document before that stylesheet is applied. 
- Because the theme colors aren't available yet, the browser falls back to its default canvas color (white), producing the flash.

Fix:
- Add inline styles to the `html` element to prevent initial white flash.

---

<details>
<summary>Screen recording - Before (warning: bright flashes)</summary>

https://github.com/user-attachments/assets/e3c01ef6-1d09-475e-a081-1b390894f750

</details>

<details>
<summary>Screen recording - After - Dark theme</summary>

https://github.com/user-attachments/assets/721c273c-b30e-4627-aa90-878829341dca

</details>

<details>
<summary>Screen recording - After - Light theme</summary>

https://github.com/user-attachments/assets/7fc711d1-3fbc-4c0b-8cb9-52412d558db1

</details>

<!-- Feel free to add any additional description of changes below this line -->
