### PR TITLE
docs: fix moderator handbook link

### DIFF
--- a/src/content/docs/moderator-onboarding-guide.mdx
+++ b/src/content/docs/moderator-onboarding-guide.mdx
@@ -5,7 +5,7 @@ title: The Official freeCodeCamp Moderator Onboarding Guide
 This guide will help new moderators get up and running with the processes and procedures followed by experienced moderators on the freeCodeCamp community forum and other official communities we foster.
 
 :::note
-If you haven't read [The Moderator Handbook](./moderator-handbook/) yet, you should start there first.
+If you haven't read [The Moderator Handbook](/moderator-handbook/) yet, you should start there first.
 :::
 
 ## The Forum


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1355

<!-- Feel free to add any additional description of changes below this line -->

This PR fixes the Moderator Handbook link in the Moderator Onboarding Guide.

The previous link used a relative path, `./moderator-handbook/`, which did not navigate to the existing Moderator Handbook page. This updates the link to use the correct internal path: `/moderator-handbook/`.