### PR TITLE
fix: update Node.js version to 24.x in docs site prerequisites

### DIFF
--- a/src/content/docs/how-to-work-on-the-docs-site.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-site.mdx
@@ -127,7 +127,7 @@ You now have a copy of freeCodeCamp's documentation site running in your Codespa
 
 | Prerequisite                         | Version | Notes                           |
 | ------------------------------------ | ------- | ------------------------------- |
-| [Node.js](http://nodejs.org)         | `22.x`  | We use the "Active LTS" version |
+| [Node.js](http://nodejs.org)         | `24.x`  | We use the "Active LTS" version |
 | [pnpm](https://pnpm.io/installation) | `10.x`  |                                 |
 
 </Card>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1357

<!-- Feel free to add any additional description of changes below this line -->
Updates the Node.js prerequisite from `22.x` to `24.x` to match the project's `.nvmrc` file.