### PR TITLE
fix(docs): update invalid hash links in PR and moderator handbooks

### DIFF
--- a/src/content/docs/how-to-open-a-pull-request.mdx
+++ b/src/content/docs/how-to-open-a-pull-request.mdx
@@ -127,5 +127,5 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://discord.gg/PRyKn3Vbay).
 
 :::tip
-If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-setup-freecodecamp-locally/#set-up-syncing-from-parent) guidelines to avoid having to delete your fork.
+If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-contribute-to-the-codebase/#contributing-to-the-codebase) guidelines to avoid having to delete your fork.
 :::

--- a/src/content/docs/how-to-open-a-pull-request.mdx
+++ b/src/content/docs/how-to-open-a-pull-request.mdx
@@ -127,5 +127,5 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://discord.gg/PRyKn3Vbay).
 
 :::tip
-If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-setup-freecodecamp-locally/#making-changes-locally) guidelines to avoid having to delete your fork.
+If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-setup-freecodecamp-locally/#set-up-syncing-from-parent) guidelines to avoid having to delete your fork.
 :::

--- a/src/content/docs/moderator-handbook.mdx
+++ b/src/content/docs/moderator-handbook.mdx
@@ -27,7 +27,7 @@ freeCodeCamp is an inclusive community, and we need to keep it that way.
 We have a single [Code of Conduct](https://code-of-conduct.freecodecamp.org) that governs our entire community. The fewer the rules, the easier they are to remember. You can read those rules and commit them to memory [here](https://code-of-conduct.freecodecamp.org).
 
 :::note
-As a moderator, we would add you to one or more teams on GitHub, our community forums & chat servers. If you are missing access to a platform that you would like to moderate, please [reach out to a staff member](/faq/#additional-assistance).
+As a moderator, we would add you to one or more teams on GitHub, our community forums & chat servers. If you are missing access to a platform that you would like to moderate, please [reach out to a staff member](/faq/#where-can-i-get-help-if-im-stuck-on-something-not-covered-here).
 :::
 
 ## Moderating GitHub


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1365

<!-- Feel free to add any additional description of changes below this line -->
This PR resolves the Starlight link validation errors (`invalid hash`) that occur during the local docs build. 

Specifically, it fixes the invalid markdown hash links in:
- `how-to-open-a-pull-request.mdx` (updated to point to `#set-up-syncing-from-parent` which matches the actual heading in the local setup guide).
- `moderator-handbook.mdx` (updated to point to `#where-can-i-get-help-if-im-stuck-on-something-not-covered-here` matching the real FAQ section heading).

Built the docs site locally on Fedora 43 / Chrome and verified that the `invalid hash` errors for these specific files are no longer present in the Starlight output.