### PR TITLE
docs: document functionRegex capture nested blocks limitation

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -534,6 +534,27 @@ const match =
 match[1]; // "myFunc = arg1 => arg1; console.log();\n // captured, unfortunately"
 ```
 
+NOTE: `capture: true` does not work correctly for regular functions whose body contains nested blocks (`if`, `try`, `for`, etc.). The captured content is truncated at the first `}` inside the body, so everything after the first closing brace of a nested block is silently excluded.
+
+```js
+const regEx = __helpers.functionRegex('registerUser', [], { capture: true });
+
+const match = `function registerUser() {
+  if (name.trim() === "") {
+    throw new Error("Name is required");
+  }
+  if (age.trim() === "") {
+    throw new Error("Age is required");
+  }
+}`.match(regEx);
+
+match[1];
+// Ends at the closing } of the first if block.
+// match[1].includes('age.trim') === false
+```
+
+For functions with nested blocks, match directly against `code` instead of relying on `match[1]`.
+
 #### `.getFunctionParams()`
 
 Available via `__helpers.getFunctionParams(codeString)`, this method extracts parameter information from a function definition string.

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -553,7 +553,7 @@ match[1];
 // match[1].includes('age.trim') === false
 ```
 
-For functions with nested blocks, match directly against `code` instead of relying on `match[1]`.
+For functions with nested blocks, match directly against `code` or the stringified function instead of relying on `match[1]`.
 
 #### `.getFunctionParams()`
 

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -548,9 +548,8 @@ const match = `function registerUser() {
   }
 }`.match(regEx);
 
-match[1];
-// Ends at the closing } of the first if block.
-// match[1].includes('age.trim') === false
+match[1].includes('throw new Error("Name is required")'); // true — first if block IS captured
+match[1].includes('age.trim'); // false — second if block is NOT captured
 ```
 
 For functions with nested blocks, match directly against `code` or the stringified function instead of relying on `match[1]`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Related: freeCodeCamp/curriculum-helpers#583

<!-- Feel free to add any additional description of changes below this line -->

Adds a note to the `functionRegex()` docs about a known limitation with `capture: true`: the captured content is truncated at the first `}` inside the body when the function contains nested blocks (`if`, `try`, `for`, etc.). Includes a code example to make the failure mode concrete.

The existing docs already note the arrow function caveat; this brings the nested-blocks limitation to the same level of visibility.
