### PR TITLE
chore: rename how to contribute to basic git workflow

### DIFF
--- a/src/content/docs/basic-git-workflow.mdx
+++ b/src/content/docs/basic-git-workflow.mdx
@@ -1,7 +1,7 @@
 ---
-title: Contribute to the Codebase
+title: Basic Git Workflow
 sidebar:
-  label: Work on Codebase
+  label: Basic Git Workflow
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -117,9 +117,11 @@ Follow these steps:
 
 5. Once you are happy with the changes you should optionally run freeCodeCamp to preview the changes.
 
-6. Make sure you fix any errors and check the formatting of your changes.
+6. You should run any relevant test commands. For example, if you have edited a challenge; you should run a command to test that challenge.
 
-7. Check and confirm the files you are updating:
+7. Make sure you fix any errors and check the formatting of your changes.
+
+8. Check and confirm the files you are updating:
 
    ```bash
    git status
@@ -142,7 +144,7 @@ Follow these steps:
    ...
    ```
 
-8. Stage the changes and make a commit:
+9. Stage the changes and make a commit:
 
    In this step, you should only mark files that you have edited or added yourself. You can perform a reset and resolve files that you did not intend to change if needed.
 
@@ -207,15 +209,15 @@ Follow these steps:
 
    You can learn more about why you should use conventional commits [here](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits).
 
-9. If you realize that you need to edit a file or update the commit message after making a commit you can do so after editing the files with:
+10. If you realize that you need to edit a file or update the commit message after making a commit you can do so after editing the files with:
 
-   ```bash
-   git commit --amend
-   ```
+    ```bash
+    git commit --amend
+    ```
 
-   This will open up a default text editor like `nano` or `vi` where you can edit the commit message title and add/edit the description.
+    This will open up a default text editor like `nano` or `vi` where you can edit the commit message title and add/edit the description.
 
-10. Next, you can push your changes to your fork:
+11. Next, you can push your changes to your fork:
 
     ```bash
     git push origin branch/name-here

--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -11,7 +11,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 ### I'm new to GitHub and open source. Where should I start?
 
-See our [How to Contribute to Open Source Guide](https://github.com/freeCodeCamp/how-to-contribute-to-open-source). It's a beginner-friendly resource with tips for contributing to open-source projects.
+See our [Basic Git Flow document](https://github.com/freeCodeCamp/basic-git-workflow). It's a beginner-friendly resource with tips for contributing to open-source projects.
 
 ### What do I need to know to contribute to the codebase?
 

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -75,7 +75,7 @@ Our curriculum is curated by the global freeCodeCamp community. You can help exp
 
 2. **Learn the Git workflow**
 
-   Read [how to contribute to the codebase](/how-to-contribute-to-the-codebase/) for our branching and commit conventions.
+   Read [about how our Git workflow guide](/basic-git-workflow/) for our branching and commit conventions.
 
 3. **Work on curriculum challenges**
 
@@ -113,7 +113,7 @@ Our learning platform runs on a modern JavaScript stack including Node.js, Mongo
 
 2. **Learn the Git workflow**
 
-   Read [how to contribute to the codebase](/how-to-contribute-to-the-codebase/) for our branching and commit conventions.
+   Read [about how our Git workflow works](/basic-git-workflow/) for our branching and commit conventions.
 
 3. **Review codebase best practices**
 
@@ -181,7 +181,7 @@ Contribute to the freeCodeCamp mobile application, available on iOS and Android.
 
 2. **Learn the Git workflow**
 
-   Read [how to contribute to the codebase](/how-to-contribute-to-the-codebase/) for our branching and commit conventions.
+   Read [how our Git workflow works](/basic-git-workflow/) for our branching and commit conventions.
 
 3. **Submit your changes**
 
@@ -203,7 +203,7 @@ Help improve this very documentation site you're reading! Good documentation hel
 
 2. **Learn the Git workflow**
 
-   Read [how to contribute to the codebase](/how-to-contribute-to-the-codebase/) for our branching and commit conventions.
+   Read [our Git workflow guide](/basic-git-workflow/) for our branching and commit conventions.
 
 3. **Make your improvements**
 

--- a/src/content/docs/how-to-open-a-pull-request.mdx
+++ b/src/content/docs/how-to-open-a-pull-request.mdx
@@ -127,5 +127,5 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://discord.gg/PRyKn3Vbay).
 
 :::tip
-If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/how-to-contribute-to-the-codebase/#contributing-to-the-codebase) guidelines to avoid having to delete your fork.
+If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](/basic-git-workflow/#contributing-to-the-codebase) guidelines to avoid having to delete your fork.
 :::

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -8,7 +8,7 @@ const sidebar = [
     items: [
       'how-to-setup-freecodecamp-locally',
       'codebase-best-practices',
-      'how-to-contribute-to-the-codebase',
+      'basic-git-workflow',
       'how-to-work-on-coding-challenges',
       'how-to-work-on-quizzes',
       'how-to-work-on-reviews',

--- a/tests/sidebar-structure.test.ts
+++ b/tests/sidebar-structure.test.ts
@@ -117,7 +117,7 @@ describe('Sidebar Structure', () => {
       const criticalGuides = [
         'how-to-setup-freecodecamp-locally',
         'codebase-best-practices',
-        'how-to-contribute-to-the-codebase',
+        'basic-git-workflow',
         'how-to-work-on-coding-challenges',
         'how-to-add-playwright-tests',
         'how-to-open-a-pull-request'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1140

<!-- Feel free to add any additional description of changes below this line -->
While I know for certain that we'll need a new redirect; this document change should be completely worth it. 

I also added the step to run any relevant test commands to try to create more of a connection to the "Quick Commands Reference" at the bottom of the page. 

Links have been updated and so were tests. 