### PR TITLE
docs: clarify Node.js version requirement

### DIFF
--- a/src/content/docs/how-to-work-on-the-docs-site.mdx
+++ b/src/content/docs/how-to-work-on-the-docs-site.mdx
@@ -242,6 +242,18 @@ You need a reference from your local clone to the `upstream` repository in addit
 
 ## Install Dependencies
 
+Before installing dependencies, ensure you are using the supported Node.js version.
+
+We recommend using Node.js 24.x (Active LTS) and managing Node.js versions with a tool such as fnm or nvm.
+
+Verify your Node.js version:
+
+```bash
+node -v
+```
+
+The output should show Node.js 24.x.
+
 First, ensure you have pnpm installed globally:
 
 ```bash


### PR DESCRIPTION
##Checklist

- [x ] I have read [freeCodeCamp's contribution guidelines.
- [x ] My pull request has a descriptive title

Closes #1353

## Description

Adds a note to the documentation setup guide explaining the required Node.js version before running `pnpm install`.

### Changes

- Added guidance to use Node.js 24.x (Active LTS)
- Added a command to verify the installed Node.js version
- Mentioned version managers such as fnm and nvm
