### PR TITLE
standardize Discord link and fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This code is running live at [contribute.freecodecamp.org](https://contribute.fr
 
 Our community is active across multiple platforms. Join us to get help, give feedback, or chat with other learners:
 
-* **[Forum](https://forum.freecodecamp.org):** Get programming help or project feedback within hours.
-* **[YouTube Channel](https://youtube.com/freecodecamp):** Free comprehensive courses on Python, SQL, Web Development, and more.
-* **[Technical Publication](https://www.freecodecamp.org/news):** Thousands of technical tutorials and articles about coding and computer science.
-* **[Discord Server](https://chat.freecodecamp.org):** Hang out and talk in real-time with developers and students.
+- **[Forum](https://forum.freecodecamp.org):** Get programming help or project feedback within hours.
+- **[YouTube Channel](https://youtube.com/freecodecamp):** Free comprehensive courses on Python, SQL, Web Development, and more.
+- **[Technical Publication](https://www.freecodecamp.org/news):** Thousands of technical tutorials and articles about coding and computer science.
+- **[Discord Server](https://chat.freecodecamp.org):** Hang out and talk in real-time with developers and students.
 
 > #### [Join the freeCodeCamp community here](https://www.freecodecamp.org/signin)
 
@@ -26,12 +26,15 @@ Our community is active across multiple platforms. Join us to get help, give fee
 ## Guidelines and Documentation
 
 ### Reporting Bugs and Issues
+
 If you think you've found a bug, please first read the [how to report a bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions. If it's a new and verified bug, feel free to open a new GitHub issue with clear reproduction steps.
 
 ### Security Issues and Responsible Disclosure
+
 We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. Please [read our security policy](https://contribute.freecodecamp.org/security) to report any vulnerabilities safely.
 
 ### Contributing to the Docs
+
 The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to this documentation site and are excited to welcome you aboard.
 
 > #### [Please follow these steps to contribute](https://contribute.freecodecamp.org/how-to-work-on-the-docs-site)
@@ -48,5 +51,5 @@ Copyright © 2014 freeCodeCamp.org
 
 The content of this repository is bound by the following licenses:
 
-* The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
-* The documentation is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+- The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
+- The documentation is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![freeCodeCamp Social Banner](https://cdn.freecodecamp.org/platform/universal/fcc_banner_new.png)](https://www.freecodecamp.org/)
 
-[![Discord](https://img.shields.io/discord/692816967895220344?logo=discord&label=Discord&color=5865F2)](https://discord.gg/PRyKn3Vbay)
+[![Discord](https://img.shields.io/discord/692816967895220344?logo=discord&label=Discord&color=5865F2)](https://chat.freecodecamp.org)
 
 # Contribute
 
@@ -8,42 +8,45 @@
 
 This code is running live at [contribute.freecodecamp.org](https://contribute.freecodecamp.org).
 
-Our community also has:
+---
 
-- A [forum](https://forum.freecodecamp.org) where you can usually get programming help or project feedback within hours.
-- A [YouTube channel](https://youtube.com/freecodecamp) with free courses on Python, SQL, Android, and a wide variety of other technologies.
-- A [technical publication](https://www.freecodecamp.org/news) with thousands of programming tutorials and articles about mathematics and computer science.
-- A [Discord server](https://chat.freecodecamp.org) where you can hang out and talk with developers and people who are learning to code.
+## Community Channels
 
-> #### [Join the community here](https://www.freecodecamp.org/signin).
+Our community is active across multiple platforms. Join us to get help, give feedback, or chat with other learners:
+
+* **[Forum](https://forum.freecodecamp.org):** Get programming help or project feedback within hours.
+* **[YouTube Channel](https://youtube.com/freecodecamp):** Free comprehensive courses on Python, SQL, Web Development, and more.
+* **[Technical Publication](https://www.freecodecamp.org/news):** Thousands of technical tutorials and articles about coding and computer science.
+* **[Discord Server](https://chat.freecodecamp.org):** Hang out and talk in real-time with developers and students.
+
+> #### [Join the freeCodeCamp community here](https://www.freecodecamp.org/signin)
+
+---
+
+## Guidelines and Documentation
 
 ### Reporting Bugs and Issues
+If you think you've found a bug, please first read the [how to report a bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions. If it's a new and verified bug, feel free to open a new GitHub issue with clear reproduction steps.
 
-If you think you've found a bug, first read the [how to report a bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions.
+### Security Issues and Responsible Disclosure
+We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. Please [read our security policy](https://contribute.freecodecamp.org/security) to report any vulnerabilities safely.
 
-If you're confident it's a new bug and have confirmed that someone else is facing the same issue, go ahead and create a new GitHub issue. Be sure to include as much information as possible so we can reproduce the bug.
+### Contributing to the Docs
+The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to this documentation site and are excited to welcome you aboard.
 
-### Reporting Security Issues and Responsible Disclosure
+> #### [Please follow these steps to contribute](https://contribute.freecodecamp.org/how-to-work-on-the-docs-site)
 
-We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
+---
 
-> #### [Read our security policy and follow these steps to report a vulnerability](https://contribute.freecodecamp.org/security).
-
-### Contributing
-
-The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to the community and are excited to welcome you aboard.
-
-> #### [Please follow these steps to contribute](https://contribute.freecodecamp.org/how-to-work-on-the-docs-site).
-
-Recent Contributions:
+## Recent Contributions
 
 ![Alt](https://repobeats.axiom.co/api/embed/fa251dc26940513ed7a3bc2f01c3fe97c85dea84.svg 'Repobeats analytics image')
 
-### License
+## License
 
 Copyright © 2014 freeCodeCamp.org
 
 The content of this repository is bound by the following licenses:
 
-- The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
-- The documentation is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+* The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
+* The documentation is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

- Standardized the inconsistent Discord invite link in the header badge to use the uniform `chat.freecodecamp.org` domain.
- Cleaned up headers, subheadings, and bullet points layout with proper Markdown line spacing to adhere strictly to Prettier formatting guidelines.

### Checklist
- [x] My changes follow the code style of this project.
- [x] I have performed a self-review of my own changes.
