### PR TITLE
docs: move TypeScript Helpers above Python and cross-reference from JS Helper

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -687,13 +687,13 @@ explorer.allFunctions; // { foo: Explorer, bar: Explorer }
 
 #### `parameters`
 
-Returns an array of `Explorer` instances representing the parameters of a function or method.
+Returns an array of `Explorer` instances representing the parameters of a function or method. Compare them with `matches`, which works even when a parameter has no type annotation:
 
 ```js
 const explorer = await __helpers.Explorer('function foo(x, y) { return 42; }');
 const parameters = explorer.functions.foo.parameters;
-parameters[0].toString(); // x
-parameters[1].toString(); // y
+parameters[0].matches('x'); // true
+parameters[1].matches('y'); // true
 ```
 
 #### `hasReturn(value: string)`
@@ -782,6 +782,17 @@ const explorer = await __helpers.Explorer('const a: number = 1;');
 const { a } = explorer.variables;
 a.hasAnnotation('number'); // true
 a.hasAnnotation('string'); // false
+```
+
+This also works on a [parameter](#parameters). When a parameter has a type annotation, `matches` compares the full `name: type` and `hasAnnotation` checks the type alone:
+
+```js
+const explorer = await __helpers.Explorer(
+  'function foo(x: number) { return 42; }'
+);
+const [x] = explorer.functions.foo.parameters;
+x.matches('x: number'); // true
+x.hasAnnotation('number'); // true
 ```
 
 #### `hasReturnAnnotation(annotation: string)`

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -577,6 +577,364 @@ __helpers.escapeRegExp('hello.world'); // "hello\\.world"
 __helpers.escapeRegExp('test[123]'); // "test\\[123\\]"
 ```
 
+### AST-based Helpers
+
+The `Explorer` class provides Abstract Syntax Tree (AST) analysis of the camper's code. It is a chainable class whose methods operate on the result of parsing a string.
+
+`Explorer` is built on the TypeScript compiler's parser, so the methods documented here inspect language features shared by JavaScript and TypeScript (variables, functions, classes, and so on). Because these features are present in vanilla JavaScript, the methods below can be used to test both JavaScript and TypeScript challenges. The methods that test TypeScript-specific features are documented under [TypeScript Helpers](#typescript-helpers).
+
+#### Basic Usage
+
+Create an instance of `Explorer` that parses the camper's code:
+
+```js
+const explorer = await __helpers.Explorer(code);
+```
+
+To access a specific statement within the code you need to chain method calls until you reach the desired scope. For example, if the camper has written the following code:
+
+```js
+class Spam {
+  get42() {
+    return 42;
+  }
+}
+```
+
+you can drill down to the method and check its return value:
+
+```js
+const explorer = await __helpers.Explorer(code);
+assert.isTrue(explorer.classes.Spam.methods.get42.hasReturn('42'));
+```
+
+#### `isEmpty()`
+
+Returns `true` if the Explorer instance has no AST node, otherwise returns `false`.
+
+```js
+const explorer = await __helpers.Explorer('const a = 1;');
+explorer.isEmpty(); // false
+```
+
+#### `toString()`
+
+Returns the source code representation of the current node, or `"no ast"` if the node is empty.
+
+```js
+const explorer = await __helpers.Explorer('const a = 1;');
+explorer.toString(); // "const a = 1;"
+```
+
+#### `matches(other: string | Explorer)`
+
+Compares the current tree with another tree or string, ignoring semicolons and irrelevant whitespace differences.
+
+```js
+const explorer = await __helpers.Explorer('const a = 1;');
+explorer.matches('const a =  1'); // true (ignores whitespace and semicolons)
+explorer.matches('const b = 1;'); // false
+```
+
+#### `variables`
+
+Returns an object mapping variable names to `Explorer` instances for all variables in the current scope.
+
+```js
+const explorer = await __helpers.Explorer(
+  'var a = 1; let b = 2; const c = () => {}'
+);
+const { a, b, c } = explorer.variables; // { a: Explorer, b: Explorer, c: Explorer }
+a.matches('var a = 1;'); // true
+b.matches('let b = 2;'); // true
+c.matches('const c = () => {}'); // true
+```
+
+#### `value`
+
+Returns an `Explorer` instance representing the assigned value of a variable, property, parameter, or property assignment. Returns an empty `Explorer` if there is no initializer.
+
+```js
+const explorer = await __helpers.Explorer('const a = 1; const b = { x: 10 };');
+const { a, b } = explorer.variables;
+a.value.toString(); // "1"
+b.value.matches('{ x: 10 }'); // true
+```
+
+#### `objectProps`
+
+Returns an object mapping property names to `Explorer` instances for all properties in an object literal.
+
+```js
+const explorer = await __helpers.Explorer(
+  "const obj = { x: 1, y: 'hello', z: true };"
+);
+const { obj } = explorer.variables;
+const props = obj.value.objectProps; // { x: Explorer, y: Explorer, z: Explorer }
+```
+
+#### `functions` and `allFunctions`
+
+`functions` returns function declarations only. `allFunctions` also includes arrow functions and function expressions assigned to variables.
+
+```js
+const explorer = await __helpers.Explorer(
+  'function foo() { return 42; } const bar = () => 24;'
+);
+explorer.functions; // { foo: Explorer }
+explorer.allFunctions; // { foo: Explorer, bar: Explorer }
+```
+
+#### `parameters`
+
+Returns an array of `Explorer` instances representing the parameters of a function or method.
+
+```js
+const explorer = await __helpers.Explorer('function foo(x, y) { return 42; }');
+const parameters = explorer.functions.foo.parameters;
+parameters[0].toString(); // x
+parameters[1].toString(); // y
+```
+
+#### `hasReturn(value: string)`
+
+Checks whether a function, method, or function-valued variable has a matching top-level return expression.
+
+```js
+const explorer = await __helpers.Explorer('function foo() { return 42; }');
+const { foo } = explorer.functions;
+foo.hasReturn('42'); // true
+```
+
+#### `classes`
+
+Returns an object mapping class names to `Explorer` instances for all classes in the current scope.
+
+```js
+const explorer = await __helpers.Explorer('class Foo {} class Bar {}');
+const { classes } = explorer; // { Foo: Explorer, Bar: Explorer }
+classes.Foo.matches('class Foo {}'); // true
+classes.Bar.matches('class Bar {}'); // true
+```
+
+#### `methods`
+
+Returns an object mapping method names to `Explorer` instances for all methods in the current class.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { method1() {} method2() {} }'
+);
+const { Foo } = explorer.classes;
+const { method1, method2 } = Foo.methods; // { method1: Explorer, method2: Explorer }
+```
+
+#### `classConstructor`, `classProps`, and `constructorProps`
+
+Use these to inspect class constructors and class-related properties.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { prop1 = 0; constructor(x) { this.y = x; } }'
+);
+const { Foo } = explorer.classes;
+Foo.classConstructor?.matches('constructor(x) { this.y = x; }'); // true
+Foo.classProps; // { prop1: Explorer }
+Foo.constructorProps; // { y: Explorer }
+```
+
+#### `doesExtend(basesToCheck: string | string[])`
+
+Checks if a class or interface extends the specified base class or interface(s). Accepts a single string or an array of strings.
+
+```js
+const explorer = await __helpers.Explorer('class Dog extends Animal {}');
+const { Dog } = explorer.classes;
+Dog.doesExtend('Animal'); // true
+Dog.doesExtend('Cat'); // false
+```
+
+## TypeScript Helpers
+
+These helpers test TypeScript-specific features. They are methods on the same `Explorer` class described under [AST-based Helpers](#ast-based-helpers): create an instance with `await __helpers.Explorer(code)` and chain the methods below alongside the shared methods documented there.
+
+### Methods and Properties
+
+#### `annotation`
+
+Returns an `Explorer` instance representing the type annotation of the current node, or an empty `Explorer` if none exists.
+
+```js
+const explorer = await __helpers.Explorer(
+  'const a: number = 1; const b: { age: number } = { age: 33 }'
+);
+const { a, b } = explorer.variables;
+a.annotation; // Explorer with "number"
+b.annotation; // Explorer with "{ age: number }"
+```
+
+#### `hasAnnotation(annotation: string)`
+
+Returns `true` if the current node has a type annotation matching the specified string.
+
+```js
+const explorer = await __helpers.Explorer('const a: number = 1;');
+const { a } = explorer.variables;
+a.hasAnnotation('number'); // true
+a.hasAnnotation('string'); // false
+```
+
+#### `hasReturnAnnotation(annotation: string)`
+
+Returns `true` if the function/method has a return type annotation matching the specified type.
+
+```js
+const explorer = await __helpers.Explorer(
+  'function foo(): number { return 42; }'
+);
+const { foo } = explorer.functions;
+foo.hasReturnAnnotation('number'); // true
+foo.hasReturnAnnotation('string'); // false
+```
+
+#### `types`
+
+Returns an object mapping type alias names to `Explorer` instances for all type aliases in the current scope.
+
+```js
+const explorer = await __helpers.Explorer(
+  'type Foo = { x: number; }; type Bar = { y: string; };'
+);
+const { types } = explorer; // { Foo: Explorer, Bar: Explorer }
+types.Foo.matches('type Foo = { x: number; };'); // true
+types.Bar.matches('type Bar = { y: string; };'); // true
+```
+
+#### `interfaces`
+
+Returns an object mapping interface names to `Explorer` instances for all interfaces in the current scope.
+
+```js
+const explorer = await __helpers.Explorer(
+  'interface Foo { x: number; } interface Bar { y: string; }'
+);
+const { interfaces } = explorer; // { Foo: Explorer, Bar: Explorer }
+interfaces.Foo.matches('interface Foo { x: number; }'); // true
+interfaces.Bar.matches('interface Bar { y: string; }'); // true
+```
+
+#### `typeProps`
+
+Returns an object mapping property names to `Explorer` instances for all properties in a type, interface, or type literal.
+
+```js
+const explorer = await __helpers.Explorer(
+  'type Foo = { x: number; y: string; };'
+);
+const { Foo } = explorer.types;
+const { x, y } = Foo.typeProps; // { x: Explorer, y: Explorer }
+```
+
+#### `hasTypeProps(props: TypeProp | TypeProp[])`
+
+Returns `true` if all specified properties exist in a type, interface, or type literal, with optional type and optionality verification. `TypeProp` is an object with the form `{ name: string; type?: string; isOptional?: boolean }`.
+
+```js
+const explorer = await __helpers.Explorer(
+  'type Foo = { x: number; y: string; z?: boolean; };'
+);
+const { Foo } = explorer.types;
+Foo.hasTypeProps({ name: 'x' }); // true
+Foo.hasTypeProps([
+  { name: 'x', type: 'number' },
+  { name: 'y', type: 'string', isOptional: false },
+  { name: 'z', isOptional: true }
+]); // true
+Foo.hasTypeProps({ name: 'a' }); // false
+```
+
+#### `isUnionOf(types: string[])`
+
+Returns `true` if the current node has a union type annotation whose members exactly match the specified types, ignoring order.
+
+```js
+const explorer = await __helpers.Explorer(
+  'const a: number | string | boolean;'
+);
+const { a } = explorer.variables;
+a.annotation.isUnionOf(['number', 'string', 'boolean']); // true
+a.annotation.isUnionOf(['number', 'string']); // false
+```
+
+#### `hasCast(expectedType?: string)`
+
+Checks if the current node is a type assertion (cast using `as`). Optionally verify the cast type matches the provided type string.
+
+```js
+const explorer = await __helpers.Explorer(
+  'const a = 1 as number; const b = 2 as string;'
+);
+const { a, b } = explorer.variables;
+a.value.hasCast(); // true
+a.value.hasCast('number'); // true
+a.value.hasCast('string'); // false
+b.value.hasCast('string'); // true
+```
+
+#### `hasNonNullAssertion()`
+
+Checks whether the current expression is a non-null assertion (`!`).
+
+```js
+const explorer = await __helpers.Explorer('const a = maybeValue!;');
+const { a } = explorer.variables;
+a.value.hasNonNullAssertion(); // true
+```
+
+#### `doesImplement(basesToCheck: string | string[])`
+
+Checks if a class implements the specified interface(s). Accepts a single string or an array of strings.
+
+```js
+const explorer = await __helpers.Explorer('class Foo implements Bar, Baz { }');
+const { Foo } = explorer.classes;
+Foo.doesImplement('Bar'); // true
+Foo.doesImplement(['Bar', 'Baz']); // true
+Foo.doesImplement('Spam'); // false
+```
+
+#### `typeParameters` and `typeArguments`
+
+`typeParameters` returns generic declarations (like `<T>`), and `typeArguments` returns generic usages (like `<string>`).
+
+```js
+const explorer = await __helpers.Explorer(
+  'function id<T>(x: T): T { return x; }'
+);
+const { id } = explorer.functions;
+id.typeParameters[0].matches('T'); // true
+
+const explorer2 = await __helpers.Explorer(
+  'const m: Map<string, number> = new Map();'
+);
+const { m } = explorer2.variables;
+m.annotation.typeArguments[0].matches('string'); // true
+```
+
+#### Access modifiers
+
+Use `isPrivate()`, `isProtected()`, `isPublic()`, and `isReadOnly()` on class members and type properties.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { private readonly x: number; }'
+);
+const { Foo } = explorer.classes;
+const { x } = Foo.classProps;
+x.isPrivate(); // true
+x.isReadOnly(); // true
+```
+
 ## Python Helper
 
 The `__helpers` object includes comprehensive Python code analysis tools through the `python` property.
@@ -1741,363 +2099,4 @@ def add(
   y
 ):
     return x + y
-```
-
-## TypeScript Helpers
-
-These helpers provide Abstract Syntax Tree (AST) analysis capabilities for TypeScript challenges.
-
-### Basic Usage
-
-`Explorer` is a chainable class that allows you to call methods on the result of parsing a string. Here's how to create an instance of `Explorer` that parses the camper's code:
-
-```js
-const explorer = await __helpers.Explorer(code);
-```
-
-To access a specific statement within the code you need to chain method calls until you reach the desired scope. For example, if the camper has written the following code:
-
-```ts
-class Spam {
-  get42(): number {
-    return 42;
-  }
-}
-```
-
-To check the return type annotation you would write:
-
-```js
-const explorer = await __helpers.Explorer(code);
-assert.isTrue(
-  explorer.classes.Spam.methods.get42.hasReturnAnnotation('number')
-);
-```
-
-### Methods and Properties
-
-#### `isEmpty()`
-
-Returns `true` if the Explorer instance has no AST node, otherwise returns `false`.
-
-```js
-const explorer = await __helpers.Explorer('const a = 1;');
-explorer.isEmpty(); // false
-```
-
-#### `toString()`
-
-Returns the source code representation of the current node, or `"no ast"` if the node is empty.
-
-```js
-const explorer = await __helpers.Explorer('const a = 1;');
-explorer.toString(); // "const a = 1;"
-```
-
-#### `matches(other: string | Explorer)`
-
-Compares the current tree with another tree or string, ignoring semicolons and irrelevant whitespace differences.
-
-```js
-const explorer = await __helpers.Explorer('const a = 1;');
-explorer.matches('const a =  1'); // true (ignores whitespace and semicolons)
-explorer.matches('const b = 1;'); // false
-```
-
-#### `variables`
-
-Returns an object mapping variable names to `Explorer` instances for all variables in the current scope.
-
-```js
-const explorer = await __helpers.Explorer(
-  'var a = 1; let b = 2; const c = () => {}'
-);
-const { a, b, c } = explorer.variables; // { a: Explorer, b: Explorer, c: Explorer }
-a.matches('var a = 1;'); // true
-b.matches('let b = 2;'); // true
-c.matches('const c = () => {}'); // true
-```
-
-#### `value`
-
-Returns an `Explorer` instance representing the assigned value of a variable, property, parameter, or property assignment. Returns an empty `Explorer` if there is no initializer.
-
-```js
-const explorer = await __helpers.Explorer('const a = 1; const b = { x: 10 };');
-const { a, b } = explorer.variables;
-a.value.toString(); // "1"
-b.value.matches('{ x: 10 }'); // true
-```
-
-#### `objectProps`
-
-Returns an object mapping property names to `Explorer` instances for all properties in an object literal.
-
-```js
-const explorer = await __helpers.Explorer(
-  "const obj = { x: 1, y: 'hello', z: true };"
-);
-const { obj } = explorer.variables;
-const props = obj.value.objectProps; // { x: Explorer, y: Explorer, z: Explorer }
-```
-
-#### `functions` and `allFunctions`
-
-`functions` returns function declarations only. `allFunctions` also includes arrow functions and function expressions assigned to variables.
-
-```js
-const explorer = await __helpers.Explorer(
-  'function foo() { return 42; } const bar = () => 24;'
-);
-explorer.functions; // { foo: Explorer }
-explorer.allFunctions; // { foo: Explorer, bar: Explorer }
-```
-
-#### `parameters`
-
-Returns an array of `Explorer` instances representing the parameters of a function or method.
-
-```js
-const explorer = await __helpers.Explorer(
-  'function foo(x: number, y: string) { return 42; }'
-);
-const parameters = explorer.functions.foo.parameters;
-parameters[0].toString(); // x: number
-parameters[1].toString(); // y: string
-```
-
-#### `annotation`
-
-Returns an `Explorer` instance representing the type annotation of the current node, or an empty `Explorer` if none exists.
-
-```js
-const explorer = await __helpers.Explorer(
-  'const a: number = 1; const b: { age: number } = { age: 33 }'
-);
-const { a, b } = explorer.variables;
-a.annotation; // Explorer with "number"
-b.annotation; // Explorer with "{ age: number }"
-```
-
-#### `hasAnnotation(annotation: string)`
-
-Returns `true` if the current node has a type annotation matching the specified string.
-
-```js
-const explorer = await __helpers.Explorer('const a: number = 1;');
-const { a } = explorer.variables;
-a.hasAnnotation('number'); // true
-a.hasAnnotation('string'); // false
-```
-
-#### `hasReturnAnnotation(annotation: string)`
-
-Returns `true` if the function/method has a return type annotation matching the specified type.
-
-```js
-const explorer = await __helpers.Explorer(
-  'function foo(): number { return 42; }'
-);
-const { foo } = explorer.functions;
-foo.hasReturnAnnotation('number'); // true
-foo.hasReturnAnnotation('string'); // false
-```
-
-#### `hasReturn(value: string)`
-
-Checks whether a function, method, or function-valued variable has a matching top-level return expression.
-
-```js
-const explorer = await __helpers.Explorer('function foo() { return 42; }');
-const { foo } = explorer.functions;
-foo.hasReturn('42'); // true
-```
-
-#### `types`
-
-Returns an object mapping type alias names to `Explorer` instances for all type aliases in the current scope.
-
-```js
-const explorer = await __helpers.Explorer(
-  'type Foo = { x: number; }; type Bar = { y: string; };'
-);
-const { types } = explorer; // { Foo: Explorer, Bar: Explorer }
-types.Foo.matches('type Foo = { x: number; };'); // true
-types.Bar.matches('type Bar = { y: string; };'); // true
-```
-
-#### `interfaces`
-
-Returns an object mapping interface names to `Explorer` instances for all interfaces in the current scope.
-
-```js
-const explorer = await __helpers.Explorer(
-  'interface Foo { x: number; } interface Bar { y: string; }'
-);
-const { interfaces } = explorer; // { Foo: Explorer, Bar: Explorer }
-interfaces.Foo.matches('interface Foo { x: number; }'); // true
-interfaces.Bar.matches('interface Bar { y: string; }'); // true
-```
-
-#### `classes`
-
-Returns an object mapping class names to `Explorer` instances for all classes in the current scope.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { x: number; } class Bar { y: string; }'
-);
-const { classes } = explorer; // { Foo: Explorer, Bar: Explorer }
-classes.Foo.matches('class Foo { x: number; }'); // true
-classes.Bar.matches('class Bar { y: string; }'); // true
-```
-
-#### `methods`
-
-Returns an object mapping method names to `Explorer` instances for all methods in the current class.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { method1() {} method2() {} }'
-);
-const { Foo } = explorer.classes;
-const { method1, method2 } = Foo.methods; // { method1: Explorer, method2: Explorer }
-```
-
-#### `classConstructor`, `classProps`, and `constructorProps`
-
-Use these to inspect class constructors and class-related properties.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { prop1: number; constructor(x) { this.y = x; } }'
-);
-const { Foo } = explorer.classes;
-Foo.classConstructor?.matches('constructor(x) { this.y = x; }'); // true
-Foo.classProps; // { prop1: Explorer }
-Foo.constructorProps; // { y: Explorer }
-```
-
-#### `typeProps`
-
-Returns an object mapping property names to `Explorer` instances for all properties in a type, interface, or type literal.
-
-```js
-const explorer = await __helpers.Explorer(
-  'type Foo = { x: number; y: string; };'
-);
-const { Foo } = explorer.types;
-const { x, y } = Foo.typeProps; // { x: Explorer, y: Explorer }
-```
-
-#### `hasTypeProps(props: TypeProp | TypeProp[])`
-
-Returns `true` if all specified properties exist in a type, interface, or type literal, with optional type and optionality verification. `TypeProp` is an object with the form `{ name: string; type?: string; isOptional?: boolean }`.
-
-```js
-const explorer = await __helpers.Explorer(
-  'type Foo = { x: number; y: string; z?: boolean; };'
-);
-const { Foo } = explorer.types;
-Foo.hasTypeProps({ name: 'x' }); // true
-Foo.hasTypeProps([
-  { name: 'x', type: 'number' },
-  { name: 'y', type: 'string', isOptional: false },
-  { name: 'z', isOptional: true }
-]); // true
-Foo.hasTypeProps({ name: 'a' }); // false
-```
-
-#### `isUnionOf(types: string[])`
-
-Returns `true` if the current node has a union type annotation whose members exactly match the specified types, ignoring order.
-
-```js
-const explorer = await __helpers.Explorer(
-  'const a: number | string | boolean;'
-);
-const { a } = explorer.variables;
-a.annotation.isUnionOf(['number', 'string', 'boolean']); // true
-a.annotation.isUnionOf(['number', 'string']); // false
-```
-
-#### `hasCast(expectedType?: string)`
-
-Checks if the current node is a type assertion (cast using `as`). Optionally verify the cast type matches the provided type string.
-
-```js
-const explorer = await __helpers.Explorer(
-  'const a = 1 as number; const b = 2 as string;'
-);
-const { a, b } = explorer.variables;
-a.value.hasCast(); // true
-a.value.hasCast('number'); // true
-a.value.hasCast('string'); // false
-b.value.hasCast('string'); // true
-```
-
-#### `hasNonNullAssertion()`
-
-Checks whether the current expression is a non-null assertion (`!`).
-
-```js
-const explorer = await __helpers.Explorer('const a = maybeValue!;');
-const { a } = explorer.variables;
-a.value.hasNonNullAssertion(); // true
-```
-
-#### `doesExtend(basesToCheck: string | string[])`
-
-Checks if a class or interface extends the specified base class or interface(s). Accepts a single string or an array of strings.
-
-```js
-const explorer = new Explorer('interface Foo extends Bar, Baz { }');
-const { Foo } = explorer.interfaces;
-Foo.doesExtend('Bar'); // true
-Foo.doesExtend(['Bar', 'Baz']); // true only if both are extended
-Foo.doesExtend('Spam'); // false
-```
-
-#### `doesImplement(basesToCheck: string | string[])`
-
-Checks if a class implements the specified interface(s). Accepts a single string or an array of strings.
-
-```js
-const explorer = await __helpers.Explorer('class Foo implements Bar, Baz { }');
-const { Foo } = explorer.classes;
-Foo.doesImplement('Bar'); // true
-Foo.doesImplement(['Bar', 'Baz']); // true
-Foo.doesImplement('Spam'); // false
-```
-
-#### `typeParameters` and `typeArguments`
-
-`typeParameters` returns generic declarations (like `<T>`), and `typeArguments` returns generic usages (like `<string>`).
-
-```js
-const explorer = await __helpers.Explorer(
-  'function id<T>(x: T): T { return x; }'
-);
-const { id } = explorer.functions;
-id.typeParameters[0].matches('T'); // true
-
-const explorer2 = await __helpers.Explorer(
-  'const m: Map<string, number> = new Map();'
-);
-const { m } = explorer2.variables;
-m.annotation.typeArguments[0].matches('string'); // true
-```
-
-#### Access modifiers
-
-Use `isPrivate()`, `isProtected()`, `isPublic()`, and `isReadOnly()` on class members and type properties.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { private readonly x: number; }'
-);
-const { Foo } = explorer.classes;
-const { x } = Foo.classProps;
-x.isPrivate(); // true
-x.isReadOnly(); // true
 ```

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -577,15 +577,31 @@ __helpers.escapeRegExp('hello.world'); // "hello\\.world"
 __helpers.escapeRegExp('test[123]'); // "test\\[123\\]"
 ```
 
-### AST-based Helpers
+### The `Explorer` Class
 
-The `Explorer` class provides Abstract Syntax Tree (AST) analysis of the camper's code. It is a chainable class whose methods operate on the result of parsing a string.
+The `Explorer` class is documented under [TypeScript Helpers](#typescript-helpers), where it is used to test TypeScript challenges. Many of its helpers, however, are not about TypeScript-specific features: they inspect language constructs that also exist in vanilla JavaScript, such as variables, functions, and classes. Those helpers can be used to test JavaScript challenges too. They are:
 
-`Explorer` is built on the TypeScript compiler's parser, so the methods documented here inspect language features shared by JavaScript and TypeScript (variables, functions, classes, and so on). Because these features are present in vanilla JavaScript, the methods below can be used to test both JavaScript and TypeScript challenges. The methods that test TypeScript-specific features are documented under [TypeScript Helpers](#typescript-helpers).
+- [`isEmpty()`](#isempty)
+- [`toString()`](#tostring)
+- [`matches()`](#matchesother-string--explorer)
+- [`variables`](#variables)
+- [`value`](#value)
+- [`objectProps`](#objectprops)
+- [`functions` and `allFunctions`](#functions-and-allfunctions)
+- [`parameters`](#parameters)
+- [`hasReturn()`](#hasreturnvalue-string)
+- [`classes`](#classes)
+- [`methods`](#methods-1)
+- [`classConstructor`, `classProps`, and `constructorProps`](#classconstructor-classprops-and-constructorprops)
+- [`doesExtend()`](#doesextendbasestocheck-string--string)
 
-#### Basic Usage
+## TypeScript Helpers
 
-Create an instance of `Explorer` that parses the camper's code:
+These helpers provide Abstract Syntax Tree (AST) analysis capabilities for TypeScript challenges.
+
+### Basic Usage
+
+`Explorer` is a chainable class that allows you to call methods on the result of parsing a string. Here's how to create an instance of `Explorer` that parses the camper's code:
 
 ```js
 const explorer = await __helpers.Explorer(code);
@@ -593,20 +609,24 @@ const explorer = await __helpers.Explorer(code);
 
 To access a specific statement within the code you need to chain method calls until you reach the desired scope. For example, if the camper has written the following code:
 
-```js
+```ts
 class Spam {
-  get42() {
+  get42(): number {
     return 42;
   }
 }
 ```
 
-you can drill down to the method and check its return value:
+To check the return type annotation you would write:
 
 ```js
 const explorer = await __helpers.Explorer(code);
-assert.isTrue(explorer.classes.Spam.methods.get42.hasReturn('42'));
+assert.isTrue(
+  explorer.classes.Spam.methods.get42.hasReturnAnnotation('number')
+);
 ```
+
+### Methods and Properties
 
 #### `isEmpty()`
 
@@ -687,78 +707,16 @@ explorer.allFunctions; // { foo: Explorer, bar: Explorer }
 
 #### `parameters`
 
-Returns an array of `Explorer` instances representing the parameters of a function or method. Compare them with `matches`, which works even when a parameter has no type annotation:
+Returns an array of `Explorer` instances representing the parameters of a function or method.
 
 ```js
-const explorer = await __helpers.Explorer('function foo(x, y) { return 42; }');
+const explorer = await __helpers.Explorer(
+  'function foo(x: number, y: string) { return 42; }'
+);
 const parameters = explorer.functions.foo.parameters;
-parameters[0].matches('x'); // true
-parameters[1].matches('y'); // true
+parameters[0].matches('x: number'); // true
+parameters[1].matches('y: string'); // true
 ```
-
-#### `hasReturn(value: string)`
-
-Checks whether a function, method, or function-valued variable has a matching top-level return expression.
-
-```js
-const explorer = await __helpers.Explorer('function foo() { return 42; }');
-const { foo } = explorer.functions;
-foo.hasReturn('42'); // true
-```
-
-#### `classes`
-
-Returns an object mapping class names to `Explorer` instances for all classes in the current scope.
-
-```js
-const explorer = await __helpers.Explorer('class Foo {} class Bar {}');
-const { classes } = explorer; // { Foo: Explorer, Bar: Explorer }
-classes.Foo.matches('class Foo {}'); // true
-classes.Bar.matches('class Bar {}'); // true
-```
-
-#### `methods`
-
-Returns an object mapping method names to `Explorer` instances for all methods in the current class.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { method1() {} method2() {} }'
-);
-const { Foo } = explorer.classes;
-const { method1, method2 } = Foo.methods; // { method1: Explorer, method2: Explorer }
-```
-
-#### `classConstructor`, `classProps`, and `constructorProps`
-
-Use these to inspect class constructors and class-related properties.
-
-```js
-const explorer = await __helpers.Explorer(
-  'class Foo { prop1 = 0; constructor(x) { this.y = x; } }'
-);
-const { Foo } = explorer.classes;
-Foo.classConstructor?.matches('constructor(x) { this.y = x; }'); // true
-Foo.classProps; // { prop1: Explorer }
-Foo.constructorProps; // { y: Explorer }
-```
-
-#### `doesExtend(basesToCheck: string | string[])`
-
-Checks if a class or interface extends the specified base class or interface(s). Accepts a single string or an array of strings.
-
-```js
-const explorer = await __helpers.Explorer('class Dog extends Animal {}');
-const { Dog } = explorer.classes;
-Dog.doesExtend('Animal'); // true
-Dog.doesExtend('Cat'); // false
-```
-
-## TypeScript Helpers
-
-These helpers test TypeScript-specific features. They are methods on the same `Explorer` class described under [AST-based Helpers](#ast-based-helpers): create an instance with `await __helpers.Explorer(code)` and chain the methods below alongside the shared methods documented there.
-
-### Methods and Properties
 
 #### `annotation`
 
@@ -784,17 +742,6 @@ a.hasAnnotation('number'); // true
 a.hasAnnotation('string'); // false
 ```
 
-This also works on a [parameter](#parameters). When a parameter has a type annotation, `matches` compares the full `name: type` and `hasAnnotation` checks the type alone:
-
-```js
-const explorer = await __helpers.Explorer(
-  'function foo(x: number) { return 42; }'
-);
-const [x] = explorer.functions.foo.parameters;
-x.matches('x: number'); // true
-x.hasAnnotation('number'); // true
-```
-
 #### `hasReturnAnnotation(annotation: string)`
 
 Returns `true` if the function/method has a return type annotation matching the specified type.
@@ -806,6 +753,16 @@ const explorer = await __helpers.Explorer(
 const { foo } = explorer.functions;
 foo.hasReturnAnnotation('number'); // true
 foo.hasReturnAnnotation('string'); // false
+```
+
+#### `hasReturn(value: string)`
+
+Checks whether a function, method, or function-valued variable has a matching top-level return expression.
+
+```js
+const explorer = await __helpers.Explorer('function foo() { return 42; }');
+const { foo } = explorer.functions;
+foo.hasReturn('42'); // true
 ```
 
 #### `types`
@@ -832,6 +789,45 @@ const explorer = await __helpers.Explorer(
 const { interfaces } = explorer; // { Foo: Explorer, Bar: Explorer }
 interfaces.Foo.matches('interface Foo { x: number; }'); // true
 interfaces.Bar.matches('interface Bar { y: string; }'); // true
+```
+
+#### `classes`
+
+Returns an object mapping class names to `Explorer` instances for all classes in the current scope.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { x: number; } class Bar { y: string; }'
+);
+const { classes } = explorer; // { Foo: Explorer, Bar: Explorer }
+classes.Foo.matches('class Foo { x: number; }'); // true
+classes.Bar.matches('class Bar { y: string; }'); // true
+```
+
+#### `methods`
+
+Returns an object mapping method names to `Explorer` instances for all methods in the current class.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { method1() {} method2() {} }'
+);
+const { Foo } = explorer.classes;
+const { method1, method2 } = Foo.methods; // { method1: Explorer, method2: Explorer }
+```
+
+#### `classConstructor`, `classProps`, and `constructorProps`
+
+Use these to inspect class constructors and class-related properties.
+
+```js
+const explorer = await __helpers.Explorer(
+  'class Foo { prop1: number; constructor(x) { this.y = x; } }'
+);
+const { Foo } = explorer.classes;
+Foo.classConstructor?.matches('constructor(x) { this.y = x; }'); // true
+Foo.classProps; // { prop1: Explorer }
+Foo.constructorProps; // { y: Explorer }
 ```
 
 #### `typeProps`
@@ -900,6 +896,17 @@ Checks whether the current expression is a non-null assertion (`!`).
 const explorer = await __helpers.Explorer('const a = maybeValue!;');
 const { a } = explorer.variables;
 a.value.hasNonNullAssertion(); // true
+```
+
+#### `doesExtend(basesToCheck: string | string[])`
+
+Checks if a class or interface extends the specified base class or interface(s). Accepts a single string or an array of strings.
+
+```js
+const explorer = await __helpers.Explorer('class Dog extends Animal {}');
+const { Dog } = explorer.classes;
+Dog.doesExtend('Animal'); // true
+Dog.doesExtend('Cat'); // false
 ```
 
 #### `doesImplement(basesToCheck: string | string[])`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

Reorganizes the `Explorer` AST helper documentation on the curriculum help page.

The `Explorer` class was documented entirely under a single **TypeScript Helpers** section at the bottom of the page, even though many of its methods inspect language features that exist in vanilla JavaScript (variables, functions, classes, and so on). This change:

- Moves the methods that work on features present in JavaScript into the **JS Helper** section, under a new **AST-based Helpers** subsection, and notes there that they can be used to test both JavaScript and TypeScript challenges.
- Scopes the **TypeScript Helpers** section to the TypeScript-specific methods only, and relocates it to sit directly below the JS Helper section.
