### PR TITLE
docs: mention Challenge Editor repository in setup guide

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -211,7 +211,9 @@ You should already have a fork of freeCodeCamp on GitHub. If not, [follow these 
      recent history/commit.
    </Aside>
 
-3. **(Optional)** The localized versions of our curriculum are stored in the [i18n-curriculum repo.](https://github.com/freeCodeCamp/i18n-curriculum) If you intend to run a localized version of the curriculum follow the next steps, or skip to the next section.
+3. **(Optional)** The localized versions of our curriculum are stored in the [i18n-curriculum repo.](https://github.com/freeCodeCamp/i18n-curriculum). If you intend to run a localized version of the curriculum, follow the next steps, or skip to the next section.
+
+   If you plan to contribute to the [Challenge Editor](https://github.com/freeCodeCamp/challenge-editor), you'll also need to clone its repository separately, as it is maintained in its own repository.
 
    **Clone the i18n-curriculum submodule:**
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #1441

## Description

Adds a note to the setup guide explaining that contributors who plan to work on the Challenge Editor should clone its separate repository, since it is maintained independently from the main freeCodeCamp repository.