### PR TITLE
docs: fix minor typos and grammar in contributor guides

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -288,7 +288,7 @@ Your Codespace comes pre-configured with all dependencies installed and services
 
    This will start both the API server and the client applications.
 
-2. Wait for the process to complete. It can take a few minutes, you will see a notification to for the `8000` port when it's ready.
+2. Wait for the process to complete. It can take a few minutes, you will see a notification for the `8000` port when it's ready.
 
 3. Click on the notification to open the client application in a new browser tab.
 

--- a/src/content/docs/how-to-work-on-coding-challenges.mdx
+++ b/src/content/docs/how-to-work-on-coding-challenges.mdx
@@ -67,7 +67,7 @@ Before you work on the curriculum, you would need to set up some tooling to help
 
 :::note
 
-The four hooks, `--before-each--`, `--before-all--`, `--after-each--` and -`-after-all--` are only evaluated when running tests.
+The four hooks, `--before-each--`, `--before-all--`, `--after-each--` and `--after-all--` are only evaluated when running tests.
 
 Due to differences in the testing environments, global variables are not handled the same way across hooks.
 
@@ -474,7 +474,7 @@ After you've committed your changes, check here for [how to open a Pull Request]
 If you are working with the step-based challenges, refer to the [Work on Workshops](/how-to-work-on-workshops/) section.
 :::
 
-### Creating a New Projects
+### Creating a New Project
 
 To create a new lecture block, workshop, lab, review page or quiz, you can run `pnpm run create-new-project` in the root directory. This opens up a command line UI that guides you through the process.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
## Summary of Changes
Fixed three minor typographic and grammatical issues in the documentation:

1. `how-to-work-on-coding-challenges.md`: Fixed stray hyphen formatting in -`-after-all--` hook.
2. `how-to-work-on-coding-challenges.md`: Corrected heading grammar from `Creating a New Projects` to `Creating a New Project`.
3. `how-to-setup-freecodecamp-locally.md`: Removed duplicate preposition `to for`.
