### PR TITLE
docs(curriculum-help): note matches() is parenthesis-sensitive

### DIFF
--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -648,13 +648,38 @@ explorer.toString(); // "const a = 1;"
 
 #### `matches(other: string | Explorer)`
 
-Compares the current tree with another tree or string, ignoring semicolons and irrelevant whitespace differences.
+Compares the current tree with another tree or string, ignoring semicolons, comments, and irrelevant whitespace differences.
 
 ```js
 const explorer = await __helpers.Explorer('const a = 1;');
 explorer.matches('const a =  1'); // true (ignores whitespace and semicolons)
 explorer.matches('const b = 1;'); // false
 ```
+
+Everything else is part of the tree and has to be identical, including parentheses. Redundant parentheses, and the optional parentheses around a single arrow function parameter, are all significant:
+
+```js
+const explorer = await __helpers.Explorer('const f = (x) => x;');
+explorer.matches('const f = (x) => x'); // true
+explorer.matches('const f = x => x'); // false
+
+const another = await __helpers.Explorer('const a = (1);');
+another.matches('const a = 1'); // false
+```
+
+Because of this, `matches()` is a strict check on one exact way of writing an expression. Whenever a step allows more than one valid form, compare against every form, or drill into the tree and assert on the parts that matter:
+
+```js
+const validForms = [
+  'items.find((item) => item.id === id)',
+  'items.find(item => item.id === id)',
+  'items.find((item) => { return item.id === id; })',
+  'items.find(item => { return item.id === id; })'
+];
+assert.isTrue(validForms.some(form => found.value.matches(form)));
+```
+
+Note that a list like this still ties campers to the parameter name `item` and to an arrow function, so prefer inspecting the tree when the step does not require either.
 
 #### `variables`
 

--- a/src/content/docs/curriculum-help.mdx
+++ b/src/content/docs/curriculum-help.mdx
@@ -667,6 +667,14 @@ const another = await __helpers.Explorer('const a = (1);');
 another.matches('const a = 1'); // false
 ```
 
+String literals are compared by value, so the quote character does not matter. A template literal is a different kind of node, though, and never matches a plain string:
+
+```js
+const explorer = await __helpers.Explorer("const a = 'hello';");
+explorer.matches('const a = "hello"'); // true
+explorer.matches('const a = `hello`'); // false
+```
+
 Because of this, `matches()` is a strict check on one exact way of writing an expression. Whenever a step allows more than one valid form, compare against every form, or drill into the tree and assert on the parts that matter:
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The docs currently say `matches()` ignores semicolons and irrelevant whitespace, which reads as if it is a loose comparison. It is not: parentheses are part of the tree, so `x => x` does not match `(x) => x`, and `(1)` does not match `1`.

This trips up tests that check a callback with `matches()`, since a camper who omits the parentheses around a single arrow function parameter fails a correct solution.

Behavior verified against `@freecodecamp/curriculum-helpers`:

| comparison | result |
| --- | --- |
| `const f = (x) => x` vs `const f = x => x` | `false` |
| `const a = (1)` vs `const a = 1` | `false` |
| `f(a, b,)` vs `f(a, b)` | `false` |
| `const a = 1; // comment` vs `const a = 1;` | `true` |
| `const a = {\n x: 1\n}` vs `const a = { x: 1 }` | `true` |

So this also adds comments to the list of ignored differences, and adds guidance on handling steps that accept more than one valid form.
