### PR TITLE
docs: add reply templates for discord discussion and first-timers-only closures

### DIFF
--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -141,7 +141,7 @@ Hey @username
 
 Thank you for opening this pull request and for your interest in contributing to freeCodeCamp.
 
-This issue is labeled `first timers only`, which means it's reserved for contributors who have not yet had a pull request merged into our repository. Since this label exists to help newcomers make their first contribution, we have to close this PR to keep it available for a first-time contributor.
+The linked issue is labeled `first timers only`, which means it's reserved for contributors who have not yet had a pull request merged into our repository. Since this label exists to help newcomers make their first contribution, we have to close this PR to keep it available for a first-time contributor.
 
 This is nothing against the quality of your work — we'd love to see you contribute elsewhere! Feel free to look for issues labeled `help wanted`.
 

--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -275,7 +275,7 @@ This issue has not been triaged yet, and a solution has not been agreed upon. On
 
 > When a PR needs a design/approach discussion with a maintainer before review can continue.
 
-```
+```markdown
 Hi @username
 
 Thanks for your work on this PR! 🙌

--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -280,7 +280,7 @@ Hi @username
 
 Thanks for your work on this PR! 🙌
 
-Before we can move forward with the review, we'd like you to hop into our Discord and have a quick discussion with `@naomi_lgbt` about the approach taken here. There are a few points that would be easier to sort out in a live conversation than back-and-forth on GitHub.
+Before we can move forward with the review, we'd like you to hop into our [Discord](https://chat.freecodecamp.org/) and have a quick discussion with `@naomi_lgbt` about the approach taken here. There are a few points that would be easier to sort out in a live conversation than back-and-forth on GitHub.
 
 Once you've had that conversation and reached an agreement on the approach, feel free to come back and continue with this PR. 😊
 

--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -134,7 +134,7 @@ We are closing this pull request. Please suggest links and other details to add 
 If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
 ```
 
-> When PR is submitted for an issue labeled first timers only but contributor isn't eligible.
+> When PR is submitted for an issue labeled `first timers only` but contributor isn't eligible.
 
 ```markdown
 Hey @username

--- a/src/content/docs/reply-templates.mdx
+++ b/src/content/docs/reply-templates.mdx
@@ -134,6 +134,20 @@ We are closing this pull request. Please suggest links and other details to add 
 If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
 ```
 
+> When PR is submitted for an issue labeled first timers only but contributor isn't eligible.
+
+```markdown
+Hey @username
+
+Thank you for opening this pull request and for your interest in contributing to freeCodeCamp.
+
+This issue is labeled `first timers only`, which means it's reserved for contributors who have not yet had a pull request merged into our repository. Since this label exists to help newcomers make their first contribution, we have to close this PR to keep it available for a first-time contributor.
+
+This is nothing against the quality of your work — we'd love to see you contribute elsewhere! Feel free to look for issues labeled `help wanted`.
+
+Thank you and happy coding. 😊
+```
+
 ## Adding Comment About Newbie Mistakes
 
 ```markdown
@@ -255,4 +269,20 @@ Hi there,
 Thanks for your interest in contributing.
 
 This issue has not been triaged yet, and a solution has not been agreed upon. Once the issue is open for contribution, you are welcome to create a pull request to reflect the issue consensus. Please also note that we typically do not assign issues. Instead, we accept the first pull request that comprehensively solves the issue.
+```
+
+## Requesting Discord Discussion
+
+> When a PR needs a design/approach discussion with a maintainer before review can continue.
+
+```
+Hi @username
+
+Thanks for your work on this PR! 🙌
+
+Before we can move forward with the review, we'd like you to hop into our Discord and have a quick discussion with `@naomi_lgbt` about the approach taken here. There are a few points that would be easier to sort out in a live conversation than back-and-forth on GitHub.
+
+Once you've had that conversation and reached an agreement on the approach, feel free to come back and continue with this PR. 😊
+
+Until then, we'll pause further review on this PR.
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As per the discussion on the discord, I've added reply templates for discord discussion and first-timers-only closure.
