### PR TITLE
This PR addresses the GitHub Codespaces issue described in freeCodeCamp/contribute#1189.

### DIFF
--- a/src/content/docs/how-to-setup-freecodecamp-locally.mdx
+++ b/src/content/docs/how-to-setup-freecodecamp-locally.mdx
@@ -446,6 +446,16 @@ If you have issues with the setup, check out the [troubleshooting section](/trou
 
 ## Quick Commands Reference
 
+<Aside type='caution' title='Note for GitHub Codespaces users'>
+
+If you are working in GitHub Codespaces and see GraphQL errors or a `failed - createPages` message when running any of the commands below, run the environment variable assignment and the command as two statements joined with `&&`. For example:
+
+```bash
+FCC_BLOCK='basic-html-and-html5' && pnpm run develop
+```
+
+</Aside>
+
 <Card title='Handy Scripts to use locally' icon='open-book'>
 
 | Command                                                      | Description                                                                                                   |


### PR DESCRIPTION
What I changed
Added a caution note to the local setup documentation for GitHub Codespaces users.
Documented the workaround of running environment-variable commands with && as separate statements when the prefixed command can fail in Codespaces.
Kept the change limited to src/content/docs/how-to-setup-freecodecamp-locally.mdx.
Validation
Astro checks passed
Lint passed
All 129 tests passed
Production build passed
Verified the updated documentation locally

Closes freeCodeCamp/contribute#1189