### PR TITLE
docs: refresh component library guide

### DIFF
--- a/src/content/docs/how-to-work-on-the-component-library.mdx
+++ b/src/content/docs/how-to-work-on-the-component-library.mdx
@@ -23,13 +23,17 @@ The following steps are recommended when working on a new component:
 
 ## Researching and Planning
 
-Before building a component, you need to research and document on how the existing version behaves and looks, to ensure that the new one has matching styles and supports all the current usages. In order to meet the web accessibility requirements, you should also pay attention to the accessibility aspect of the component, see which HTML elements and ARIA attributes are used under the hood.
+Before building or modifying a component, review the existing components in the `ui` library and document the behavior, appearance, and accessibility requirements for your use cases. Check which HTML elements and ARIA attributes are appropriate and how users will interact with the component using a keyboard. When modifying an existing component, inspect its current usages so that you can preserve the behavior and styles its consumers rely on.
 
-Once you have gathered enough information about the component, you can start thinking about the props interface. Ideally, the interface should be as similar to the current version as possible, to ease the adoption later on. Since we previously used Bootstrap components and modeled our components off of those, the simplest approach is to mimic [their implementation](https://github.com/react-bootstrap/react-bootstrap/tree/master/src).
+Design the props interface around the component's requirements and the patterns used by the `ui` library. For an existing component, consider how interface changes will affect its consumers. For a new component, use related `ui` components as references and expose the props its consumers need.
+
+:::note
+The library initially modeled components after React Bootstrap to ease migration. The client [removed the React Bootstrap dependency in April 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/54289) and [replaced the Bootstrap stylesheet with the UI library's base stylesheet in June 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/55068). Bootstrap implementations can provide historical context, but new components should follow the UI library's own patterns and requirements.
+:::
 
 We prefer smaller pull requests rather than a large one, because they speed up the review time and reduce cognitive overload for the reviewers. For that reason, you should think about how you would break down the implementation and come up with a delivery plan.
 
-We recommend opening a separate GitHub issue for each component and include all the notes in the issue description. It can be used as a place to host all of your working notes, as well as a way to communicate the approach with the reviewers. We will use the issue thread for further discussion if needed. [The issue for Button component](https://github.com/freeCodeCamp/freeCodeCamp/issues/45357) can be used as a reference.
+We recommend opening a separate GitHub issue for each component and include all the notes in the issue description. It can be used as a place to host all of your working notes, as well as a way to communicate the approach with the reviewers. We will use the issue thread for further discussion if needed. [The original Button implementation issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/45357) is a historical example of documenting component requirements during the migration.
 
 ## Implementing the Component
 
@@ -66,16 +70,18 @@ There are two color "layers" in the component library:
 Generally, when using colors in a component, you should choose semantic variables over the base ones. There are exceptions, however, specifically when you are styling the component's states such as hover, active, disabled, etc. In these cases, we recommend using the base variables directly instead of creating new semantic variables, since each component can have different styles for its states.
 
 :::note
-Color definition can be found in the [`colors.css` file](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/tools/ui-components/src/colors.css). A color is only available for use if it is added to the [`tailwind.config.js` file](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/tools/ui-components/tailwind.config.js) under the `colors` property.
+Color definition can be found in the [`colors.css` file](https://github.com/freeCodeCamp/ui/blob/main/src/colors.css). A color is only available for use if it is added to the [`tailwind.config.js` file](https://github.com/freeCodeCamp/ui/blob/main/tailwind.config.js) under the `colors` property.
 :::
 
 ### Useful Links
 
-- [Tailwind CSS Configuration](https://tailwindcss.com/docs/configuration)
+- [Tailwind CSS Configuration](https://v3.tailwindcss.com/docs/configuration)
+- [UI component implementations, stories, and tests](https://github.com/freeCodeCamp/ui/tree/main/src)
+
+The following references describe the Bootstrap versions that informed the original migration:
+
 - [React Bootstrap v0.33 Docs](https://react-bootstrap-v3.netlify.app)
 - [Bootstrap 3.3.7 stylesheet](https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.css)
-- [React Bootstrap current implementation](https://github.com/react-bootstrap/react-bootstrap/tree/master/src)
-- [React Bootstrap current tests](https://github.com/react-bootstrap/react-bootstrap/tree/master/test)
 
 ## Displaying the Use Cases on Storybook
 

--- a/src/content/docs/how-to-work-on-the-component-library.mdx
+++ b/src/content/docs/how-to-work-on-the-component-library.mdx
@@ -27,13 +27,9 @@ Before building or modifying a component, review the existing components in the 
 
 Design the props interface around the component's requirements and the patterns used by the `ui` library. For an existing component, consider how interface changes will affect its consumers. For a new component, use related `ui` components as references and expose the props its consumers need.
 
-:::note
-The library initially modeled components after React Bootstrap to ease migration. The client [removed the React Bootstrap dependency in April 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/54289) and [replaced the Bootstrap stylesheet with the UI library's base stylesheet in June 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/55068). Bootstrap implementations can provide historical context, but new components should follow the UI library's own patterns and requirements.
-:::
-
 We prefer smaller pull requests rather than a large one, because they speed up the review time and reduce cognitive overload for the reviewers. For that reason, you should think about how you would break down the implementation and come up with a delivery plan.
 
-We recommend opening a separate GitHub issue for each component and include all the notes in the issue description. It can be used as a place to host all of your working notes, as well as a way to communicate the approach with the reviewers. We will use the issue thread for further discussion if needed. [The original Button implementation issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/45357) is a historical example of documenting component requirements during the migration.
+We recommend opening a separate GitHub issue for each component and include all the notes in the issue description. It can be used as a place to host all of your working notes, as well as a way to communicate the approach with the reviewers. We will use the issue thread for further discussion if needed.
 
 ## Implementing the Component
 
@@ -77,11 +73,6 @@ Color definition can be found in the [`colors.css` file](https://github.com/free
 
 - [Tailwind CSS Configuration](https://v3.tailwindcss.com/docs/configuration)
 - [UI component implementations, stories, and tests](https://github.com/freeCodeCamp/ui/tree/main/src)
-
-The following references describe the Bootstrap versions that informed the original migration:
-
-- [React Bootstrap v0.33 Docs](https://react-bootstrap-v3.netlify.app)
-- [Bootstrap 3.3.7 stylesheet](https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.css)
 
 ## Displaying the Use Cases on Storybook
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

The component library guide still links to files removed from the main repository and presents the Bootstrap migration strategy as the default for new components.

- Update the `colors.css` and `tailwind.config.js` links to their locations in `freeCodeCamp/ui`.
- Link to the Tailwind v3 configuration guide. The UI library uses Tailwind 3.4.18, while the previous URL redirects to v4 documentation.
- Distinguish modifying existing components, where compatibility with consumers matters, from designing new components around current UI patterns and requirements. Keep the accessibility guidance and explicitly include keyboard interaction.
- Remove the historical Button issue reference and Bootstrap documentation/source/test links. Direct contributors to the UI library's implementations, stories, and tests instead.

The client removed [React Bootstrap in April 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/54289) and [the Bootstrap stylesheet in June 2024](https://github.com/freeCodeCamp/freeCodeCamp/pull/55068), so the guide should describe current component development rather than the completed migration.

Validation: all 129 tests pass across 7 files; full lint and Astro checks pass; the production build completes with all internal links valid.
