### PR TITLE
docs: update user token workflow

### DIFF
--- a/src/content/docs/user-token-workflow.mdx
+++ b/src/content/docs/user-token-workflow.mdx
@@ -8,12 +8,18 @@ User tokens are used to identify users to third parties so challenges completed 
 
 ## How they are Created
 
-At the moment, the tokens are only used to submit the Relational Database challenges. A token gets created when a signed-in user clicks the "Click here to start the course" or "Click here to start the project" buttons to start one of the Relational Database courses or projects.
+User tokens are used to submit challenges completed through CodeRoad and freeCodeCamp OS, including Relational Database and Back End Development and APIs courses and projects.
+
+A token gets created when a signed-in user clicks "Generate User Token" in a challenge's setup instructions. The user then clicks "Copy User Token" and follows the instructions to add it to their course environment. Starting a course or project does not generate a token.
 
 ## When they Get Deleted
 
-A user token will be deleted when a user signs out of freeCodeCamp, resets their progress, deletes their account, or manually deletes the token using the widget on the settings page.
+A user token will be deleted when a user resets all their progress, deletes their account, or manually deletes the token using the widget on the settings page. Generating a new token also deletes any existing tokens for that user. Signing out of freeCodeCamp does not delete the token.
 
 ## How they Work
 
-Tokens are stored in a `UserToken` collection in the database. Each record has a unique `_id`, which is the token, and a `user_id` that links to the user's account from the `user` collection. The token is encoded using JWT and sent to the client when it's created. That encoded token is then given to third-party services that need it and sent to our API by them when a challenge is completed. When our API gets it, it is decoded so we can identify the user submitting a challenge and save the completed challenge to their `completedChallenges`.
+Tokens are stored in a `UserToken` collection in the database. Each record has a unique `_id`, exposed as `id` in Prisma, and a `userId` that links to the user's account in the `user` collection. The API signs the token ID in a JWT and sends it to the client when it's created.
+
+The course environment sends that JWT to the `/coderoad-challenge-completed` endpoint in the `coderoad-user-token` header when a challenge is completed. The API verifies the JWT and looks up the token record to identify the user.
+
+Practice challenges are saved to the user's `completedChallenges`. For certification projects that are not already completed, the API first saves the project to `partiallyCompletedChallenges`. The user must then submit their public repository URL on the challenge page to complete the project.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The user token guide describes an outdated creation flow and says signing out deletes the token. Update it to match the current client and API:

- Include Back End Development and APIs courses, which also use user tokens through freeCodeCamp OS.
- Explain that users generate and copy tokens with the dedicated setup buttons. Starting a course does not generate a token.
- Remove sign-out from the deletion triggers and explain that generating another token replaces the existing one. The sign-out handler only clears cookies.
- Replace `user_id` with `userId` and clarify that Prisma maps `id` to the database's `_id` field.
- Describe JWT verification and distinguish practice completions from certification projects, which are initially recorded in `partiallyCompletedChallenges` until the user submits their repository URL.

Validation: Prettier check for the edited guide and `git diff --check` passed. No application runtime tests were run for this documentation-only change.
